### PR TITLE
Add OTA, Timesync and Grafana Stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -290,6 +290,11 @@ ehthumbs.db
 # Folder config file
 Desktop.ini
 
+# PlatformIO build output
+.pio/
+firmware.bin
+platformio.local.ini
+
 # Recycle Bin used on file shares
 $RECYCLE.BIN/
 

--- a/PylontechMonitoring.ino
+++ b/PylontechMonitoring.ino
@@ -346,7 +346,7 @@ struct pylonBattery
 {
   bool isPresent;
   long  soc;     //Coulomb in %
-  long  voltage; //in mW
+  long  voltage; //in mV
   long  current; //in mA, negative value is discharge
   long  tempr;   //temp of case or BMS?
   long  cellTempLow;
@@ -410,13 +410,13 @@ struct batteryStack
     return true;
   }
 
-  //in wH
+  //in W
   long getPowerDC() const
   {
     return (long)(((double)currentDC/1000.0)*((double)avgVoltage/1000.0));
   }
 
-  //wH estimated current on AC side (taking into account Sofar ME3000SP losses)
+  //W estimated power on AC side (taking into account Sofar ME3000SP losses)
   long getEstPowerAc() const
   {
     double powerDC = (double)getPowerDC();
@@ -776,6 +776,7 @@ void pushBatteryDataToMqtt(const batteryStack& lastSentData, bool forceUpdate /*
 {
   mqtt_publish_f(MQTT_TOPIC_ROOT "soc",          g_stack.soc,                lastSentData.soc,                0, forceUpdate);
   mqtt_publish_f(MQTT_TOPIC_ROOT "temp",         (float)g_stack.temp/1000.0, (float)lastSentData.temp/1000.0, 0, forceUpdate);
+  mqtt_publish_i(MQTT_TOPIC_ROOT "powerDC",      g_stack.getPowerDC(),       lastSentData.getPowerDC(),      10, forceUpdate);
   mqtt_publish_i(MQTT_TOPIC_ROOT "estPowerAC",   g_stack.getEstPowerAc(),    lastSentData.getEstPowerAc(),   10, forceUpdate);
   mqtt_publish_i(MQTT_TOPIC_ROOT "battery_count",g_stack.batteryCount,       lastSentData.batteryCount,       0, forceUpdate);
   mqtt_publish_s(MQTT_TOPIC_ROOT "base_state",   g_stack.baseState,          lastSentData.baseState            , forceUpdate);

--- a/README.md
+++ b/README.md
@@ -28,6 +28,57 @@ The MQTT refresh interval is configured there and defaults to 10 seconds. `/metr
 
 `MQTT_VALUE_PREFIX` in `platformio.local.ini` controls the legacy MQTT value prefix. With topic root `Pylontech` and prefix `US2000CBattery`, SOC is published as `Pylontech/US2000CBatterysoc`.
 
+## Optional external monitoring stack
+
+The `external` directory contains a small Docker Compose monitoring stack:
+
+### Why this stack?
+
+- **Prometheus** scrapes the ESP's `/metrics` endpoint and handles metric collection.
+- **VictoriaMetrics** provides efficient long-term metric storage with very good compression.
+- **Loki** stores battery event logs, making it easier to investigate when a battery reports an error or changes state unexpectedly.
+
+- [`external/docker-compose.yml`](external/docker-compose.yml) starts Prometheus, VictoriaMetrics, and Loki with persistent local data directories.
+- [`external/prometheus/prometheus.yml`](external/prometheus/prometheus.yml) scrapes the ESP every 30 seconds. Change `192.168.5.45:80` to your ESP address.
+- [`external/loki/loki-config.yml`](external/loki/loki-config.yml) stores IoT streams for up to ten years. Configure the ESP Loki URI as `http://<docker-host>:3100/loki/api/v1/push`.
+
+Install Docker with Compose, then start the services from the repository root:
+
+```console
+cd external
+docker compose up -d
+docker compose ps
+```
+
+Prometheus is exposed on port `9091`, VictoriaMetrics on `8428`, and Loki on `3100`. Ensure the ESP network can reach the Docker host on the required ports. The included Prometheus configuration scrapes locally but does not remote-write into VictoriaMetrics unless you add that configuration yourself.
+
+## Home Assistant MQTT sensors
+
+First connect Home Assistant to the same MQTT broker used by the ESP. Add the following to Home Assistant's `config/configuration.yaml`, then validate the configuration and restart Home Assistant. If an `mqtt:` section already exists, merge these entries into its existing `sensor:` list instead of adding a second `mqtt:` key.
+
+```yaml
+mqtt:
+  sensor:
+    # =========================================
+    # PYLONTECH MQTT
+    # =========================================
+    - name: "Battery Raw Power"
+      state_topic: "Pylontech/US2000CBatterypowerDC"
+      value_template: "{{ value }}"
+      unit_of_measurement: "W"
+      device_class: power
+      state_class: measurement
+
+    - name: "Battery State of Charge"
+      state_topic: "Pylontech/US2000CBatterysoc"
+      value_template: "{{ value }}"
+      unit_of_measurement: "%"
+      device_class: battery
+      state_class: measurement
+```
+
+The topics must match the ESP's MQTT topic root and `MQTT_VALUE_PREFIX` settings.
+
 ## Source layout
 
 - `src/main.cpp` owns shared state and composes setup/loop.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,43 @@
 This project allows you to control and monitor Pylontech US2000B, US2000C, US3000C and US5000 batteries via console port over WiFi.
 It it's a great starting point to integrate battery with your home automation.
 
+## PlatformIO setup
+
+1. Copy `platformio.local.example.ini` to `platformio.local.ini`.
+2. Set WiFi and hostname values in `platformio.local.ini`.
+3. Build with `pio run` (or `py -m platformio run`).
+4. Flash the first installation with `pio run --target upload`.
+
+`platformio.local.ini` is ignored by Git. PlatformIO injects its values as build definitions. The default target is a Wemos D1 mini; change `board` in `platformio.ini` when using another ESP8266 board. The resulting OTA image is `.pio/build/esp8266/firmware.bin`.
+
+Run `./build.ps1` to build and copy the OTA image to `firmware.bin` in the project root.
+
+The web UI at `/` includes a drag-and-drop firmware updater. Drop the generated `firmware.bin` onto it; the ESP validates and writes the image, then reboots after success. ArduinoOTA remains available using `OTA_HOSTNAME`.
+
+Prometheus can scrape `/metrics`. It exposes the same `power`, `battery`, and `battery_stat` metric families, names, labels, state codes, and unit conversions as Pylontech-Battery-Exporter. Each scrape queries `pwr` and `bat N`; `stat N` values are cached for one hour. The namespace defaults to `devicemon` and is changed at `/settings`.
+
+MQTT, Loki, the Prometheus namespace, optional ESP free-heap metric, and the NTP server are configured at `/settings`. Values are stored in LittleFS and survive reboot and OTA firmware updates.
+
+Loki support is disabled by default. Set its full `http://.../loki/api/v1/push` URI, data type, and service name, then enable it. The logger reads new battery `log` entries every five minutes and uses each entry's `ModID` as the Loki `device` label. `/settings` shows the last attempt, connection result, event counts, network route, next run, and a manual run button. The same details are available as JSON at `/logger-status`.
+
+The dashboard displays ESP and battery time. ESP time is shown in Europe/Berlin with automatic MEZ/MESZ conversion. The sync button sets the ESP and battery clocks from the browser's local PC time.
+
+The MQTT refresh interval is configured there and defaults to 10 seconds. `/metrics` collects a complete fresh dataset on each request and returns it as one response.
+
+`MQTT_VALUE_PREFIX` in `platformio.local.ini` controls the legacy MQTT value prefix. With topic root `Pylontech` and prefix `US2000CBattery`, SOC is published as `Pylontech/US2000CBatterysoc`.
+
+## Source layout
+
+- `src/main.cpp` owns shared state and composes setup/loop.
+- `src/communication.cpp` handles the Pylontech serial protocol, time sync, parsing, and battery models.
+- `src/settings.cpp` handles LittleFS persistence and settings migration.
+- `src/web.cpp` contains HTTP handlers, JSON output, and Prometheus exposition.
+- `src/ota.cpp` handles browser firmware uploads.
+- `src/mqtt.cpp` handles MQTT publishing and reconnects.
+- `src/logger.cpp` polls battery events and pushes them to Loki.
+
+The focused source files are composed through `main.cpp` as one translation unit. `build_src_filter` prevents PlatformIO from compiling them a second time. This preserves the firmware's existing shared state and memory footprint without exposing mutable globals through a broad internal API.
+
 **I ACCEPT NO RESPONSIBILTY FOR ANY DAMAGE CAUSED, PROCEED AT YOUR OWN RISK**
 
 # Features:

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,29 @@
+$ErrorActionPreference = 'Stop'
+
+$projectDir = $PSScriptRoot
+$localConfig = Join-Path $projectDir 'platformio.local.ini'
+$source = Join-Path $projectDir '.pio\build\esp8266\firmware.bin'
+$destination = Join-Path $projectDir 'firmware.bin'
+
+if (-not (Test-Path -LiteralPath $localConfig)) {
+    throw 'Missing platformio.local.ini. Copy platformio.local.example.ini and fill in your settings.'
+}
+
+if (Get-Command pio -ErrorAction SilentlyContinue) {
+    & pio run --project-dir $projectDir --environment esp8266
+} elseif (Get-Command py -ErrorAction SilentlyContinue) {
+    & py -3.12 -m platformio run --project-dir $projectDir --environment esp8266
+} else {
+    throw 'PlatformIO was not found. Install it with: py -3.12 -m pip install platformio'
+}
+
+if ($LASTEXITCODE -ne 0) {
+    throw "PlatformIO build failed with exit code $LASTEXITCODE."
+}
+
+if (-not (Test-Path -LiteralPath $source)) {
+    throw "Build succeeded but firmware was not found at: $source"
+}
+
+Copy-Item -LiteralPath $source -Destination $destination -Force
+Write-Host "Created $destination"

--- a/external/docker-compose.yml
+++ b/external/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    restart: unless-stopped
+    container_name: prometheus
+    volumes:
+      - ./prometheus:/etc/prometheus
+      - ./prom_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=24h'
+      - '--web.enable-lifecycle'
+      - '--web.enable-admin-api'
+    ports:
+      - "9091:9090"
+    depends_on:
+      - victoriametrics
+
+  victoriametrics:
+    image: victoriametrics/victoria-metrics:latest
+    restart: unless-stopped
+    container_name: victoria
+    ports:
+      - "8428:8428"
+    volumes:
+      - ./victoria_data:/storage
+    command:
+      - "-retentionPeriod=10y"
+      - "-storageDataPath=/storage"
+      - "-selfScrapeInterval=60s"
+
+  loki:
+    image: grafana/loki:latest
+    restart: unless-stopped
+    container_name: loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - ./loki_data:/loki
+    command:
+      - "-config.file=/etc/loki/loki-config.yml"

--- a/external/loki/loki-config.yml
+++ b/external/loki/loki-config.yml
@@ -1,0 +1,65 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  replication_factor: 1
+
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+ingester:
+  chunk_idle_period: 30m
+  max_chunk_age: 2h
+  chunk_target_size: 1572864
+  chunk_encoding: gzip
+
+  wal:
+    enabled: true
+    dir: /loki/wal
+
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+
+  filesystem:
+    directory: /loki/chunks
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+
+  retention_enabled: true
+  retention_delete_delay: 2h
+  delete_request_store: filesystem
+
+limits_config:
+  # Default retention for streams without a matching rule (90 Days)
+  retention_period: 2160h
+
+  retention_stream:
+    # IoT data: ~10 years
+    - selector: '{data_type="iot"}'
+      priority: 10
+      period: 87600h
+
+    # Program logs: ~3 months
+    - selector: '{data_type="program"}'
+      priority: 5
+      period: 2160h

--- a/external/prometheus/prometheus.yml
+++ b/external/prometheus/prometheus.yml
@@ -1,0 +1,24 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+          # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  # - "first_rules.yml"
+  # - "second_rules.yml"
+
+scrape_configs:
+  - job_name: "PylontechBattery"
+    scrape_interval: 30s
+    scrape_timeout: 20s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["192.168.5.45:80"]

--- a/libraries/NtpTime/ntp_time.h
+++ b/libraries/NtpTime/ntp_time.h
@@ -3,9 +3,6 @@
 
 #include <WiFiUdp.h>
 
-// NTP Servers:
-static const char ntpServerName[] = "0.uk.pool.ntp.org";
-const int timeZone = 0;
 unsigned int localPort = 8888;       // local port to listen for UDP packets
 
 /*-------- NTP code ----------*/
@@ -38,7 +35,7 @@ void sendNTPpacket(IPAddress &address)
 }
 
 
-time_t getNtpTime()
+time_t getNtpTime(const char* serverName)
 {
   if(WiFi.status() != WL_CONNECTED)
   {
@@ -56,7 +53,10 @@ time_t getNtpTime()
 
   while (udpNtp.parsePacket() > 0) ; // discard any previously received packets
   // get a random server from the pool
-  WiFi.hostByName(ntpServerName, ntpServerIP);
+  if(WiFi.hostByName(serverName, ntpServerIP) != 1)
+  {
+    return 0;
+  }
   sendNTPpacket(ntpServerIP);
   delay(100);
   
@@ -71,7 +71,7 @@ time_t getNtpTime()
       secsSince1900 |= (unsigned long)packetBuffer[41] << 16;
       secsSince1900 |= (unsigned long)packetBuffer[42] << 8;
       secsSince1900 |= (unsigned long)packetBuffer[43];
-      return secsSince1900 - 2208988800UL + timeZone * SECS_PER_HOUR;
+      return secsSince1900 - 2208988800UL;
     }
 
     delay(10);

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,22 @@
+[platformio]
+default_envs = esp8266
+extra_configs = platformio.local.ini
+
+[common]
+build_flags =
+  -I libraries/SimpleTimer
+  -I libraries/NtpTime
+  -I libraries/Misc
+
+[env:esp8266]
+platform = espressif8266
+board = d1_mini
+framework = arduino
+monitor_speed = 115200
+lib_extra_dirs = libraries
+build_src_filter =
+  +<main.cpp>
+lib_deps =
+  knolleary/PubSubClient@^2.8
+  paulstoffregen/Time@^1.6.1
+build_flags = ${common.build_flags}

--- a/platformio.local.example.ini
+++ b/platformio.local.example.ini
@@ -1,0 +1,19 @@
+[env:esp8266]
+build_flags =
+  ${common.build_flags}
+  -D WIFI_SSID=\"your-wifi-ssid\"
+  -D WIFI_PASS=\"your-wifi-password\"
+  -D WIFI_HOSTNAME=\"PylontechBattery\"
+  -D OTA_HOSTNAME=\"GarageBattery\"
+  -D MQTT_ENABLED_DEFAULT=1
+  -D MQTT_SERVER_DEFAULT=\"192.168.0.95\"
+  -D MQTT_PORT_DEFAULT=1883
+  -D MQTT_USER_DEFAULT=\"devices\"
+  -D MQTT_PASSWORD_DEFAULT=\"\"
+  -D MQTT_TOPIC_ROOT_DEFAULT=\"Pylontech\"
+  -D MQTT_VALUE_PREFIX=\"US2000CBattery\"
+  -D NTP_SERVER_DEFAULT=\"pool.ntp.org\"
+  -D LOKI_ENABLED_DEFAULT=0
+  -D LOKI_URI_DEFAULT=\"http://192.168.0.95:3100/loki/api/v1/push\"
+  -D LOKI_DATA_TYPE_DEFAULT=\"iot\"
+  -D LOKI_SERVICE_NAME_DEFAULT=\"pylontech-battery\"

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -1,95 +1,3 @@
-#include <ESP8266WiFi.h>
-#include <ESP8266mDNS.h>
-#include <ArduinoOTA.h>
-#include <ESP8266WebServer.h>
-#include <ESP8266WebServer.h>
-#include <SimpleTimer.h>
-#include <TimeLib.h> //https://github.com/PaulStoffregen/Time
-#include <ntp_time.h>
-#include <circular_log.h>
-
-
-//IMPORTANT: Specify your WIFI settings:
-#define WIFI_SSID "--YOUR SSID HERE --"
-#define WIFI_PASS "-- YOUR PASSWORD HERE --"
-
-//IMPORTANT: Uncomment this line if you want to enable MQTT (and fill correct MQTT_ values below):
-//#define ENABLE_MQTT
-
-#ifdef ENABLE_MQTT
-//NOTE 1: if you want to change what is pushed via MQTT - edit function: pushBatteryDataToMqtt.
-//NOTE 2: MQTT_TOPIC_ROOT is where battery will push MQTT topics. For example "soc" will be pushed to: "home/grid_battery/soc"
-#define MQTT_SERVER        "192.168.0.6"
-#define MQTT_PORT          1883
-#define MQTT_USER          ""
-#define MQTT_PASSWORD      ""
-#define MQTT_TOPIC_ROOT    "home/grid_battery/"  //this is where mqtt data will be pushed
-#define MQTT_PUSH_FREQ_SEC 2  //maximum mqtt update frequency in seconds
-
-#include <PubSubClient.h>
-WiFiClient espClient;
-PubSubClient mqttClient(espClient);
-#endif //ENABLE_MQTT
-
-char g_szRecvBuff[7000];
-
-ESP8266WebServer server(80);
-SimpleTimer timer;
-circular_log<7000> g_log;
-bool ntpTimeReceived = false;
-int g_baudRate = 0;
-
-void Log(const char* msg)
-{
-  g_log.Log(msg);
-}
-
-void setup() {
-  pinMode(LED_BUILTIN, OUTPUT); 
-  digitalWrite(LED_BUILTIN, HIGH);//high is off
-  
-  // put your setup code here, to run once:
-  WiFi.mode(WIFI_STA);
-  WiFi.persistent(false); //our credentialss are hardcoded, so we don't need ESP saving those each boot (will save on flash wear)
-  WiFi.hostname("PylontechBattery");
-  WiFi.begin(WIFI_SSID, WIFI_PASS);
-
-  for(int ix=0; ix<10; ix++)
-  {
-    if(WiFi.status() == WL_CONNECTED)
-    {
-      break;
-    }
-
-    delay(1000);
-  }
-
-  ArduinoOTA.setHostname("GarageBattery");
-  ArduinoOTA.begin();
-  server.on("/", handleRoot);
-  server.on("/log", handleLog);
-  server.on("/req", handleReq);
-  server.on("/jsonOut", handleJsonOut);
-  server.on("/reboot", [](){
-    ESP.restart();
-  });
-  
-  server.begin(); 
-  
-  syncTime();
-
-#ifdef ENABLE_MQTT
-  mqttClient.setServer(MQTT_SERVER, MQTT_PORT);
-#endif
-
-  Log("Boot event");
-}
-
-void handleLog()
-{
-  server.send(200, "text/html", g_log.c_str());
-}
-
 void switchBaud(int newRate)
 {
   if(g_baudRate == newRate)
@@ -115,27 +23,27 @@ void switchBaud(int newRate)
   delay(20);
 }
 
-void waitForSerial()
+void waitForSerial(int loops)
 {
-  for(int ix=0; ix<150;ix++)
+  for(int ix=0; ix<loops;ix++)
   {
     if(Serial.available()) break;
     delay(10);
   }
 }
 
-int readFromSerial()
+int readFromSerial(int waitLoops = 150)
 {
   memset(g_szRecvBuff, 0, sizeof(g_szRecvBuff));
   int recvBuffLen = 0;
-  bool foundTerminator = true;
+  bool foundTerminator = false;
   
-  waitForSerial();
+  waitForSerial(waitLoops);
   
   while(Serial.available())
   {
     char szResponse[256] = "";
-    const int readNow = Serial.readBytesUntil('>', szResponse, sizeof(szResponse)-1); //all commands terminate with "$$\r\n\rpylon>" (no new line at the end)
+    const int readNow = Serial.readBytesUntil('>', szResponse, sizeof(szResponse)-1);
     if(readNow > 0 && 
        szResponse[0] != '\0')
     {
@@ -148,7 +56,8 @@ int readFromSerial()
       strcat(g_szRecvBuff, szResponse);
       recvBuffLen += readNow;
 
-      if(strstr(g_szRecvBuff, "$$\r\n\rpylon"))
+      const size_t responseLength = strlen(g_szRecvBuff);
+      if(responseLength >= 5 && strcmp(g_szRecvBuff + responseLength - 5, "pylon") == 0)
       {
         strcat(g_szRecvBuff, ">"); //readBytesUntil will skip this, so re-add
         foundTerminator = true;
@@ -161,7 +70,7 @@ int readFromSerial()
         Serial.write("\r");
       }
 
-      waitForSerial();
+      waitForSerial(waitLoops);
     }
   }
 
@@ -188,9 +97,12 @@ bool readFromSerialAndSendResponse()
   return false;
 }
 
-bool sendCommandAndReadSerialResponse(const char* pszCommand)
+bool sendCommandAndReadSerialResponse(const char* pszCommand, bool wakeRetry, int waitLoops)
 {
   switchBaud(115200);
+
+  // Discard bytes left by a previous background command.
+  while(Serial.available()) Serial.read();
 
   if(pszCommand[0] != '\0')
   {
@@ -198,13 +110,17 @@ bool sendCommandAndReadSerialResponse(const char* pszCommand)
   }
   Serial.write("\n");
 
-  const int recvBuffLen = readFromSerial();
-  if(recvBuffLen > 0)
+  const int recvBuffLen = readFromSerial(waitLoops);
+  const bool complete = strstr(g_szRecvBuff, "pylon>") != NULL;
+  const bool rejected = strstr(g_szRecvBuff, "Unknown command") != NULL;
+  if(recvBuffLen > 0 && !rejected && (pszCommand[0] == '\0' || complete))
   {
     return true;
   }
 
-  //wake up console and try again:
+  if(!wakeRetry) return false;
+
+  // Wake the console and retry foreground requests.
   wakeUpConsole();
 
   if(pszCommand[0] != '\0')
@@ -213,69 +129,10 @@ bool sendCommandAndReadSerialResponse(const char* pszCommand)
   }
   Serial.write("\n");
 
-  return readFromSerial() > 0;
-}
-
-void handleReq()
-{
-  bool respOK;
-  if(server.hasArg("code") == false)
-  {
-    respOK = sendCommandAndReadSerialResponse("");
-  }
-  else
-  {
-    respOK = sendCommandAndReadSerialResponse(server.arg("code").c_str());
-  }
-
-  if(respOK)
-  {
-    server.send(200, "text/plain", g_szRecvBuff);
-  }
-  else
-  {
-    server.send(500, "text/plain", "????");
-  }
-}
-
-void handleJsonOut()
-{
-  if(sendCommandAndReadSerialResponse("pwr") == false)
-  {
-    server.send(500, "text/plain", "Failed to get response to 'pwr' command");
-    return;
-  }
-
-  parsePwrResponse(g_szRecvBuff);
-  prepareJsonOutput(g_szRecvBuff, sizeof(g_szRecvBuff));
-  server.send(200, "application/json", g_szRecvBuff);
-}
-
-void handleRoot() {
-  unsigned long days = 0, hours = 0, minutes = 0;
-  unsigned long val = os_getCurrentTimeSec();
-  
-  days = val / (3600*24);
-  val -= days * (3600*24);
-  
-  hours = val / 3600;
-  val -= hours * 3600;
-  
-  minutes = val / 60;
-  val -= minutes*60;
-  
-  static char szTmp[2500] = "";  
-  snprintf(szTmp, sizeof(szTmp)-1, "<html><b>Garage Battery</b><br>Time GMT: %d/%02d/%02d %02d:%02d:%02d (%s)<br>Uptime: %02d:%02d:%02d.%02d<br><br>free heap: %u<br>Wifi RSSI: %d<BR>Wifi SSID: %s", 
-            year(), month(), day(), hour(), minute(), second(), "GMT",
-            (int)days, (int)hours, (int)minutes, (int)val, 
-            ESP.getFreeHeap(), WiFi.RSSI(), WiFi.SSID().c_str());
-
-
-  strncat(szTmp, "<BR><a href='/log'>Runtime log</a><HR>", sizeof(szTmp)-1);
-  strncat(szTmp, "<form action='/req' method='get'>Command:<input type='text' name='code'/><input type='submit'></form><a href='/req?code=pwr'>Power</a> | <a href='/req?code=help'>Help</a> | <a href='/req?code=log'>Event Log</a> | <a href='/req?code=time'>Time</a>", sizeof(szTmp)-1);
-  strncat(szTmp, "</html>", sizeof(szTmp)-1);
-  
-  server.send(200, "text/html", szTmp);
+  const int retryLength = readFromSerial();
+  return retryLength > 0 &&
+         strstr(g_szRecvBuff, "Unknown command") == NULL &&
+         (pszCommand[0] == '\0' || strstr(g_szRecvBuff, "pylon>") != NULL);
 }
 
 unsigned long os_getCurrentTimeSec()
@@ -298,12 +155,12 @@ unsigned long os_getCurrentTimeSec()
 
 void syncTime()
 {
-  //get time from NTP
-  time_t currentTimeGMT = getNtpTime();
+  time_t currentTimeGMT = getNtpTime(mqttSettings.ntpServer);
   if(currentTimeGMT)
   {
     ntpTimeReceived = true;
     setTime(currentTimeGMT);
+    timer.setTimeout(NTP_RESYNC_INTERVAL_MS, syncTime);
   }  
   else
   {
@@ -320,7 +177,7 @@ void wakeUpConsole()
   Serial.write("~20014682C0048520FCC3\r");
   delay(1000);
 
-  byte newLineBuff[] = {0x0E, 0x0A};
+  byte newLineBuff[] = {0x0D, 0x0A};
   switchBaud(115200);
   
   for(int ix=0; ix<10; ix++)
@@ -340,8 +197,6 @@ void wakeUpConsole()
   }
 }
 
-#define MAX_PYLON_BATTERIES 8
-
 struct pylonBattery
 {
   bool isPresent;
@@ -360,6 +215,7 @@ struct pylonBattery
   char time[20];        //2019-06-08 04:00:29
   char b_v_st[9];       //Normal  (battery voltage?)
   char b_t_st[9];       //Normal  (battery temperature?)
+  char mosTempr[12];
 
   bool isCharging()    const { return strcmp(baseState, "Charge")   == 0; }
   bool isDischarging() const { return strcmp(baseState, "Dischg")   == 0; }
@@ -543,13 +399,6 @@ int findOffset(const char *pStr, const char *param)
     return -1; /* "Power" line not found */
 }
 
-#define DECL_FIND_OFFSET_OR_FAIL(var, str, key)   \
-    int var = findOffset((str), (key));           \
-    if ((var) == -1) {                            \
-        Log(key " not found");                    \
-        return false;                             \
-    }
-
 bool parsePwrResponse(const char* pStr)
 {
   if(strstr(pStr, "Command completed successfully") == NULL)
@@ -583,6 +432,8 @@ bool parsePwrResponse(const char* pStr)
   DECL_FIND_OFFSET_OR_FAIL(offset13, pStr,"Vlow ");
   DECL_FIND_OFFSET_OR_FAIL(offset14, pStr,"Vhigh ");    
   DECL_FIND_OFFSET_OR_FAIL(offset15, pStr,"Coulomb ");
+  int offsetMos = findOffset(pStr, "MosTempr");
+  if(offsetMos < 0) offsetMos = findOffset(pStr, "MosTemp");
   
   for(int ix=0; ix<MAX_PYLON_BATTERIES; ix++)
   {
@@ -626,6 +477,7 @@ bool parsePwrResponse(const char* pStr)
       g_stack.batts[ix].cellVoltLow    = extractInt(pLineStart, offset13);
       g_stack.batts[ix].cellVoltHigh   = extractInt(pLineStart, offset14);
       g_stack.batts[ix].soc            = extractInt(pLineStart, offset15);
+      if(offsetMos >= 0) extractStr(pLineStart, offsetMos, g_stack.batts[ix].mosTempr, sizeof(g_stack.batts[ix].mosTempr));
 
       //////////////////////////////// Post-process ////////////////////////
       g_stack.batteryCount++;
@@ -695,135 +547,3 @@ bool parsePwrResponse(const char* pStr)
 
   return true;
 }
-
-void prepareJsonOutput(char* pBuff, int buffSize)
-{
-  memset(pBuff, 0, buffSize);
-  snprintf(pBuff, buffSize-1, "{\"soc\": %d, \"temp\": %d, \"currentDC\": %ld, \"avgVoltage\": %ld, \"baseState\": \"%s\", \"batteryCount\": %d, \"powerDC\": %ld, \"estPowerAC\": %ld, \"isNormal\": %s}", g_stack.soc, 
-                                                                                                                                                                                                            g_stack.temp, 
-                                                                                                                                                                                                            g_stack.currentDC, 
-                                                                                                                                                                                                            g_stack.avgVoltage, 
-                                                                                                                                                                                                            g_stack.baseState, 
-                                                                                                                                                                                                            g_stack.batteryCount, 
-                                                                                                                                                                                                            g_stack.getPowerDC(), 
-                                                                                                                                                                                                            g_stack.getEstPowerAc(),
-                                                                                                                                                                                                            g_stack.isNormal() ? "true" : "false");
-}
-
-void loop() {
-#ifdef ENABLE_MQTT
-  mqttLoop();
-#endif
-  
-  ArduinoOTA.handle();
-  server.handleClient();
-  timer.run();
-
-  //if there are bytes availbe on serial here - it's unexpected
-  //when we send a command to battery, we read whole response
-  //if we get anything here anyways - we will log it
-  int bytesAv = Serial.available();
-  if(bytesAv > 0)
-  {
-    if(bytesAv > 63)
-    {
-      bytesAv = 63;
-    }
-    
-    char buff[64+4] = "RCV:";
-    if(Serial.readBytes(buff+4, bytesAv) > 0)
-    {
-      digitalWrite(LED_BUILTIN, LOW);
-      delay(5);
-      digitalWrite(LED_BUILTIN, HIGH);//high is off
-
-      Log(buff);
-    }
-  }
-}
-
-#ifdef ENABLE_MQTT
-#define ABS_DIFF(a, b) (a > b ? a-b : b-a)
-void mqtt_publish_f(const char* topic, float newValue, float oldValue, float minDiff, bool force)
-{
-  char szTmp[16] = "";
-  snprintf(szTmp, 15, "%.2f", newValue);
-  if(force || ABS_DIFF(newValue, oldValue) > minDiff)
-  {
-    mqttClient.publish(topic, szTmp, false);
-  }
-}
-
-void mqtt_publish_i(const char* topic, int newValue, int oldValue, int minDiff, bool force)
-{
-  char szTmp[16] = "";
-  snprintf(szTmp, 15, "%d", newValue);
-  if(force || ABS_DIFF(newValue, oldValue) > minDiff)
-  {
-    mqttClient.publish(topic, szTmp, false);
-  }
-}
-
-void mqtt_publish_s(const char* topic, const char* newValue, const char* oldValue, bool force)
-{
-  if(force || strcmp(newValue, oldValue) != 0)
-  {
-    mqttClient.publish(topic, newValue, false);
-  }
-}
-
-void pushBatteryDataToMqtt(const batteryStack& lastSentData, bool forceUpdate /* if true - we will send all data regardless if it's the same */)
-{
-  mqtt_publish_f(MQTT_TOPIC_ROOT "soc",          g_stack.soc,                lastSentData.soc,                0, forceUpdate);
-  mqtt_publish_f(MQTT_TOPIC_ROOT "temp",         (float)g_stack.temp/1000.0, (float)lastSentData.temp/1000.0, 0, forceUpdate);
-  mqtt_publish_i(MQTT_TOPIC_ROOT "powerDC",      g_stack.getPowerDC(),       lastSentData.getPowerDC(),      10, forceUpdate);
-  mqtt_publish_i(MQTT_TOPIC_ROOT "estPowerAC",   g_stack.getEstPowerAc(),    lastSentData.getEstPowerAc(),   10, forceUpdate);
-  mqtt_publish_i(MQTT_TOPIC_ROOT "battery_count",g_stack.batteryCount,       lastSentData.batteryCount,       0, forceUpdate);
-  mqtt_publish_s(MQTT_TOPIC_ROOT "base_state",   g_stack.baseState,          lastSentData.baseState            , forceUpdate);
-  mqtt_publish_i(MQTT_TOPIC_ROOT "is_normal",    g_stack.isNormal() ? 1:0,   lastSentData.isNormal() ? 1:0,   0, forceUpdate);
-}
-
-void mqttLoop()
-{
-  //if we have problems with connecting to mqtt server, we will attempt to re-estabish connection each 1minute (not more than that)
-  static unsigned long g_lastConnectionAttempt = 0;
-
-  //first: let's make sure we are connected to mqtt
-  const char* topicLastWill = MQTT_TOPIC_ROOT "availability";
-  if (!mqttClient.connected() && (g_lastConnectionAttempt == 0 || os_getCurrentTimeSec() - g_lastConnectionAttempt > 60)) {
-    if(mqttClient.connect("GarageBattery", MQTT_USER, MQTT_PASSWORD, topicLastWill, 1, true, "offline"))
-    {
-      Log("Connected to MQTT server: " MQTT_SERVER);
-      mqttClient.publish(topicLastWill, "online", true);
-    }
-    else
-    {
-      Log("Failed to connect to MQTT server.");
-    }
-
-    g_lastConnectionAttempt = os_getCurrentTimeSec();
-  }
-
-  //next: read data from battery and send via MQTT (but only once per MQTT_PUSH_FREQ_SEC seconds)
-  static unsigned long g_lastDataSent = 0;
-  if(mqttClient.connected() && 
-     os_getCurrentTimeSec() - g_lastDataSent > MQTT_PUSH_FREQ_SEC &&
-     sendCommandAndReadSerialResponse("pwr") == true)
-  {
-    static batteryStack lastSentData; //this is the last state we sent to MQTT, used to prevent sending the same data over and over again
-    static unsigned int callCnt = 0;
-    
-    parsePwrResponse(g_szRecvBuff);
-
-    bool forceUpdate = (callCnt % 20 == 0); //push all the data every 20th call
-    pushBatteryDataToMqtt(lastSentData, forceUpdate);
-    
-    callCnt++;
-    g_lastDataSent = os_getCurrentTimeSec();
-    memcpy(&lastSentData, &g_stack, sizeof(batteryStack));
-  }
-  
-  mqttClient.loop();
-}
-
-#endif //ENABLE_MQTT

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,0 +1,451 @@
+struct LokiEvent
+{
+  uint32_t index;
+  char time[20];
+  char modId[16];
+  char code[16];
+  String info;
+  time_t utc;
+};
+
+static unsigned long loggerLastPoll = 0;
+static uint32_t loggerLastFingerprint = 0;
+static bool loggerFingerprintLoaded = false;
+static unsigned long loggerLastAttempt = 0;
+static unsigned long loggerLastDuration = 0;
+static int loggerEventsFound = 0;
+static int loggerEventsSent = 0;
+static int loggerEventsSkipped = 0;
+static int loggerHttpStatus = 0;
+static char loggerState[20] = "waiting";
+static String loggerDetail = "Not run yet";
+static bool loggerLastPushSkippable = false;
+
+// Update the visible logger state.
+static void setLoggerStatus(const char* state, const char* detail)
+{
+  strlcpy(loggerState, state, sizeof(loggerState));
+  loggerDetail = detail;
+}
+
+// Copy one field from a log block.
+static bool readLogField(const char* start, const char* end, const char* name, char* out, size_t size)
+{
+  const char* pos = strstr(start, name);
+  if(!pos || pos >= end) return false;
+  pos = strchr(pos, ':');
+  if(!pos || pos >= end) return false;
+  do pos++; while(pos < end && (*pos == ' ' || *pos == '\t'));
+
+  const char* lineEnd = pos;
+  while(lineEnd < end && *lineEnd != '\r' && *lineEnd != '\n') lineEnd++;
+  while(lineEnd > pos && isspace((unsigned char)lineEnd[-1])) lineEnd--;
+  size_t length = lineEnd - pos;
+  if(length >= size) return false;
+  memcpy(out, pos, length);
+  out[length] = '\0';
+  return length > 0;
+}
+
+// Copy a variable-length log field.
+static bool readLogField(const char* start, const char* end, const char* name, String& out)
+{
+  const char* pos = strstr(start, name);
+  if(!pos || pos >= end) return false;
+  pos = strchr(pos, ':');
+  if(!pos || pos >= end) return false;
+  do pos++; while(pos < end && (*pos == ' ' || *pos == '\t'));
+
+  const char* lineEnd = pos;
+  while(lineEnd < end && *lineEnd != '\r' && *lineEnd != '\n') lineEnd++;
+  while(lineEnd > pos && isspace((unsigned char)lineEnd[-1])) lineEnd--;
+  if(lineEnd == pos) return false;
+  out = "";
+  return out.concat(pos, lineEnd - pos);
+}
+
+// Return the last Sunday of a month.
+static int lastSunday(int yearValue, int monthValue)
+{
+  tmElements_t parts;
+  parts.Second = 0;
+  parts.Minute = 0;
+  parts.Hour = 12;
+  parts.Day = 31;
+  parts.Month = monthValue;
+  parts.Year = CalendarYrToTm(yearValue);
+  return 31 - (weekday(makeTime(parts)) - 1);
+}
+
+// Convert a Berlin wall-clock time to UTC.
+static time_t batteryTimeToUtc(const char* value)
+{
+  int yy, monthValue, dayValue, hourValue, minuteValue, secondValue;
+  if(sscanf(value, "%d-%d-%d %d:%d:%d", &yy, &monthValue, &dayValue, &hourValue, &minuteValue, &secondValue) != 6) return 0;
+  int yearValue = yy < 100 ? 2000 + yy : yy;
+  if(monthValue < 1 || monthValue > 12 || dayValue < 1 || dayValue > 31 || hourValue > 23 || minuteValue > 59 || secondValue > 59) return 0;
+
+  bool summer = monthValue > 3 && monthValue < 10;
+  if(monthValue == 3)
+  {
+    int changeDay = lastSunday(yearValue, 3);
+    summer = dayValue > changeDay || (dayValue == changeDay && hourValue >= 2);
+  }
+  else if(monthValue == 10)
+  {
+    int changeDay = lastSunday(yearValue, 10);
+    summer = dayValue < changeDay || (dayValue == changeDay && hourValue < 3);
+  }
+
+  tmElements_t parts;
+  parts.Second = secondValue;
+  parts.Minute = minuteValue;
+  parts.Hour = hourValue;
+  parts.Day = dayValue;
+  parts.Month = monthValue;
+  parts.Year = CalendarYrToTm(yearValue);
+  return makeTime(parts) - (summer ? 7200 : 3600);
+}
+
+// Parse an event by its newest-first position.
+static bool logEventAt(const char* response, int wanted, LokiEvent& event)
+{
+  const char* cursor = response;
+  for(int position = 0; (cursor = strstr(cursor, "Index")) != NULL; position++)
+  {
+    const char* colon = strchr(cursor, ':');
+    if(!colon) break;
+    const char* next = strstr(colon + 1, "Index");
+    const char* end = next ? next : response + strlen(response);
+    if(position == wanted)
+    {
+      event.index = 0;
+      event.time[0] = '\0';
+      event.modId[0] = '\0';
+      event.code[0] = '\0';
+      event.info = "";
+      event.utc = 0;
+      event.index = strtoul(colon + 1, NULL, 10);
+      if(!readLogField(cursor, end, "Time", event.time, sizeof(event.time)) ||
+         !readLogField(cursor, end, "ModID", event.modId, sizeof(event.modId)) ||
+         !readLogField(cursor, end, "Code", event.code, sizeof(event.code)) ||
+         !readLogField(cursor, end, "Info", event.info)) return false;
+      event.utc = batteryTimeToUtc(event.time);
+      return event.utc != 0;
+    }
+    cursor = colon + 1;
+  }
+  return false;
+}
+
+// Identify an event across shifting display indexes.
+static uint32_t logFingerprint(const LokiEvent& event)
+{
+  uint32_t hash = 2166136261UL;
+  const char* fields[] = {event.time, event.modId, event.code, event.info.c_str()};
+  for(unsigned int field = 0; field < sizeof(fields) / sizeof(fields[0]); field++)
+  {
+    for(const char* p = fields[field]; *p; p++)
+    {
+      hash ^= (uint8_t)*p;
+      hash *= 16777619UL;
+    }
+    hash ^= 0xff;
+    hash *= 16777619UL;
+  }
+  return hash;
+}
+
+// Escape text for JSON.
+static String jsonEscape(const char* value)
+{
+  String escaped;
+  escaped.reserve(strlen(value) + 8);
+  for(const char* p = value; *p; p++)
+  {
+    switch(*p)
+    {
+      case '\\': escaped += "\\\\"; break;
+      case '"': escaped += "\\\""; break;
+      case '\n': escaped += "\\n"; break;
+      case '\r': escaped += "\\r"; break;
+      case '\t': escaped += "\\t"; break;
+      default:
+        if((unsigned char)*p >= 0x20) escaped += *p;
+    }
+  }
+  return escaped;
+}
+
+// Parse and resolve the Loki target.
+static bool getLokiTarget(String& host, uint16_t& port, String& path, IPAddress& address)
+{
+  String uri = mqttSettings.lokiUri;
+  int start = uri.indexOf("://");
+  start = start < 0 ? 0 : start + 3;
+  int end = uri.indexOf('/', start);
+  if(end < 0) end = uri.length();
+  String authority = uri.substring(start, end);
+  int colon = authority.lastIndexOf(':');
+  host = colon > 0 ? authority.substring(0, colon) : authority;
+  port = colon > 0 ? authority.substring(colon + 1).toInt() : 80;
+  path = end < (int)uri.length() ? uri.substring(end) : "/";
+  if(host.isEmpty() || !port || path.isEmpty()) return false;
+
+  if(!address.fromString(host) && WiFi.hostByName(host.c_str(), address, 500) != 1) return false;
+  return true;
+}
+
+// Push one event to Loki.
+static bool pushLokiEvent(const LokiEvent& event)
+{
+  loggerLastPushSkippable = false;
+  if(WiFi.status() != WL_CONNECTED)
+  {
+    loggerHttpStatus = 0;
+    setLoggerStatus("error", "WiFi disconnected");
+    return false;
+  }
+
+  String line;
+  line.reserve(300);
+  line = "{\"index\":" + String(event.index) + ",\"time\":\"" + jsonEscape(event.time) + "\",\"mod_id\":\"" + jsonEscape(event.modId) + "\",\"code\":\"" + jsonEscape(event.code) + "\",\"info\":\"" + jsonEscape(event.info.c_str()) + "\"}";
+
+  String payload;
+  payload.reserve(line.length() + 300);
+  payload = "{\"streams\":[{\"stream\":{\"data_type\":\"" + jsonEscape(mqttSettings.lokiDataType) + "\",\"service_name\":\"" + jsonEscape(mqttSettings.lokiServiceName) + "\",\"device\":\"" + jsonEscape(event.modId) + "\"},\"values\":[[\"" + String((uint32_t)event.utc) + "000000000\",\"" + jsonEscape(line.c_str()) + "\"]]}]}";
+
+  String host, path;
+  uint16_t port;
+  IPAddress address;
+  if(!getLokiTarget(host, port, path, address))
+  {
+    loggerHttpStatus = 0;
+    setLoggerStatus("error", "Invalid Loki URI or DNS failed");
+    return false;
+  }
+
+  WiFiClient client;
+  client.setTimeout(4000);
+  if(!client.connect(address, port))
+  {
+    loggerHttpStatus = -1;
+    setLoggerStatus("error", "TCP connection failed");
+    return false;
+  }
+
+  client.print(F("POST "));
+  client.print(path);
+  client.print(F(" HTTP/1.1\r\nHost: "));
+  client.print(host);
+  client.print(':');
+  client.print(port);
+  client.print(F("\r\nContent-Type: application/json\r\nContent-Length: "));
+  client.print(payload.length());
+  client.print(F("\r\nConnection: close\r\n\r\n"));
+  if(client.print(payload) != payload.length())
+  {
+    client.stop();
+    loggerHttpStatus = -2;
+    setLoggerStatus("error", "Failed to write HTTP request");
+    return false;
+  }
+
+  unsigned long deadline = millis() + 5000UL;
+  while(!client.available() && client.connected() && (long)(deadline - millis()) > 0) delay(1);
+  if(!client.available())
+  {
+    client.stop();
+    loggerHttpStatus = -3;
+    setLoggerStatus("error", "No HTTP response from Loki");
+    return false;
+  }
+
+  String statusLine = client.readStringUntil('\n');
+  int space = statusLine.indexOf(' ');
+  int status = space >= 0 ? statusLine.substring(space + 1).toInt() : 0;
+  loggerHttpStatus = status;
+  String header;
+  int contentLength = -1;
+  do
+  {
+    header = client.readStringUntil('\n');
+    header.trim();
+    if(header.startsWith("Content-Length:")) contentLength = header.substring(15).toInt();
+  } while(header.length() && client.connected());
+  String response;
+  if(contentLength > 0)
+  {
+    int wanted = contentLength > 300 ? 300 : contentLength;
+    response.reserve(wanted + 1);
+    unsigned long bodyDeadline = millis() + 4000UL;
+    while((int)response.length() < wanted && (long)(bodyDeadline - millis()) > 0)
+    {
+      while(client.available() && (int)response.length() < wanted) response += (char)client.read();
+      if((int)response.length() < wanted) delay(1);
+    }
+  }
+  client.stop();
+  if(status >= 200 && status < 300) return true;
+
+  char message[32];
+  snprintf(message, sizeof(message), "Loki HTTP %d", status);
+  Log(message);
+  response.trim();
+  String lowerResponse = response;
+  lowerResponse.toLowerCase();
+  loggerLastPushSkippable = status == 400 &&
+    (lowerResponse.indexOf("timestamp too") >= 0 || lowerResponse.indexOf("too far behind") >= 0);
+  if(response.length() > 240) response = response.substring(0, 240);
+  String detail = "HTTP " + String(status);
+  if(response.length()) detail += ": " + response;
+  setLoggerStatus("error", detail.c_str());
+  return false;
+}
+
+// Read and push new battery events.
+static void runLogger()
+{
+  if(!loggerFingerprintLoaded)
+  {
+    loadLoggerFingerprint(loggerLastFingerprint);
+    loggerFingerprintLoaded = true;
+  }
+
+  loggerLastAttempt = millis();
+  unsigned long started = loggerLastAttempt;
+  loggerEventsFound = 0;
+  loggerEventsSent = 0;
+  loggerEventsSkipped = 0;
+  loggerHttpStatus = 0;
+  setLoggerStatus("reading", "Reading battery log");
+  Log("Loki: poll");
+
+  if(!sendCommandAndReadSerialResponse("log", true, 250))
+  {
+    Log("Loki log failed");
+    setLoggerStatus("error", "Battery log command failed");
+    loggerLastDuration = millis() - started;
+    return;
+  }
+
+  LokiEvent newestEvent;
+  if(!logEventAt(g_szRecvBuff, 0, newestEvent))
+  {
+    Log("Loki parse failed");
+    setLoggerStatus("error", "Battery log parse failed");
+    loggerLastDuration = millis() - started;
+    return;
+  }
+
+  int pending = 0;
+  LokiEvent event;
+  while(logEventAt(g_szRecvBuff, pending, event))
+  {
+    if(loggerLastFingerprint && logFingerprint(event) == loggerLastFingerprint) break;
+    pending++;
+  }
+  loggerEventsFound = pending;
+
+  char message[40];
+  snprintf(message, sizeof(message), "Loki: %d new", pending);
+  Log(message);
+
+  for(int position = pending - 1; position >= 0; position--)
+  {
+    snprintf(message, sizeof(message), "Sending event %d of %d", loggerEventsSent + 1, pending);
+    setLoggerStatus("sending", message);
+    if(!logEventAt(g_szRecvBuff, position, event))
+    {
+      setLoggerStatus("error", "Battery log parse failed");
+      loggerLastDuration = millis() - started;
+      return;
+    }
+    if(ntpTimeReceived && event.utc > now() + 300)
+    {
+      loggerEventsSkipped++;
+      continue;
+    }
+    if(!pushLokiEvent(event))
+    {
+      if(loggerLastPushSkippable)
+      {
+        loggerEventsSkipped++;
+        continue;
+      }
+      loggerLastDuration = millis() - started;
+      return;
+    }
+    loggerEventsSent++;
+    yield();
+  }
+
+  loggerLastFingerprint = logFingerprint(newestEvent);
+  if(!saveLoggerFingerprint(loggerLastFingerprint))
+  {
+    Log("Loki cursor save failed");
+    setLoggerStatus("error", "Events sent; cursor save failed");
+  }
+  else
+  {
+    if(loggerEventsSkipped) snprintf(message, sizeof(message), "Sent %d, skipped %d", loggerEventsSent, loggerEventsSkipped);
+    else snprintf(message, sizeof(message), pending ? "Sent %d event(s)" : "No new events", pending);
+    setLoggerStatus("ok", message);
+    Log(message);
+  }
+  loggerLastDuration = millis() - started;
+}
+
+// Poll every five minutes.
+void loggerLoop()
+{
+  if(!mqttSettings.lokiEnabled) return;
+  unsigned long current = millis();
+  if(loggerLastPoll && current - loggerLastPoll < LOKI_REFRESH_INTERVAL_MS) return;
+  loggerLastPoll = current;
+  runLogger();
+}
+
+// Return logger diagnostics.
+void handleLoggerStatus()
+{
+  long attemptAgo = loggerLastAttempt ? (long)((millis() - loggerLastAttempt) / 1000UL) : -1;
+  long nextRun = -1;
+  if(mqttSettings.lokiEnabled)
+  {
+    unsigned long elapsed = loggerLastPoll ? millis() - loggerLastPoll : LOKI_REFRESH_INTERVAL_MS;
+    nextRun = elapsed >= LOKI_REFRESH_INTERVAL_MS ? 0 : (long)((LOKI_REFRESH_INTERVAL_MS - elapsed + 999) / 1000UL);
+  }
+
+  String body;
+  body.reserve(500);
+  body = "{\"enabled\":" + String(mqttSettings.lokiEnabled ? "true" : "false") +
+         ",\"state\":\"" + jsonEscape(mqttSettings.lokiEnabled ? loggerState : "disabled") +
+         "\",\"detail\":\"" + jsonEscape(mqttSettings.lokiEnabled ? loggerDetail.c_str() : "Enable Loki in settings") +
+         "\",\"last_attempt_ago_s\":" + String(attemptAgo) +
+         ",\"last_duration_ms\":" + String(loggerLastDuration) +
+         ",\"next_run_s\":" + String(nextRun) +
+         ",\"events_found\":" + String(loggerEventsFound) +
+         ",\"events_sent\":" + String(loggerEventsSent) +
+         ",\"events_skipped\":" + String(loggerEventsSkipped) +
+         ",\"http_status\":" + String(loggerHttpStatus) +
+         ",\"free_heap\":" + String(ESP.getFreeHeap()) +
+         ",\"rssi\":" + String(WiFi.RSSI()) +
+         ",\"local_ip\":\"" + WiFi.localIP().toString() +
+         "\",\"gateway\":\"" + WiFi.gatewayIP().toString() +
+         "\",\"uri\":\"" + jsonEscape(mqttSettings.lokiUri) + "\"}";
+  server.send(200, "application/json", body);
+}
+
+// Run the logger on demand.
+void handleLoggerRun()
+{
+  if(!mqttSettings.lokiEnabled)
+  {
+    server.send(409, "text/plain", "Loki is disabled");
+    return;
+  }
+  loggerLastPoll = millis();
+  runLogger();
+  handleLoggerStatus();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,163 @@
+#include <ESP8266WiFi.h>
+#include <ESP8266mDNS.h>
+#include <ArduinoOTA.h>
+#include <ESP8266WebServer.h>
+#include <Updater.h>
+#include <SimpleTimer.h>
+#include <TimeLib.h> //https://github.com/PaulStoffregen/Time
+#include <ntp_time.h>
+#include <circular_log.h>
+#include <PubSubClient.h>
+
+#define MAX_PYLON_BATTERIES 8
+#define MAX_BATTERY_METRIC_ROWS (MAX_PYLON_BATTERIES * 16)
+#define MAX_STAT_RANGE_METRICS (MAX_PYLON_BATTERIES * 16)
+#define METRICS_COMMAND_WAIT_LOOPS 400
+#define METRICS_SEND_BUFFER_SIZE 1024
+#define STAT_REFRESH_INTERVAL_MS 3600000UL
+#define NTP_RESYNC_INTERVAL_MS 21600000UL
+#define LOKI_REFRESH_INTERVAL_MS 300000UL
+#define PROM_FREE_HEAP_DEFAULT 1
+#ifndef NTP_SERVER_DEFAULT
+#define NTP_SERVER_DEFAULT "pool.ntp.org"
+#endif
+#ifndef LOKI_ENABLED_DEFAULT
+#define LOKI_ENABLED_DEFAULT 0
+#endif
+#ifndef LOKI_URI_DEFAULT
+#define LOKI_URI_DEFAULT "http://192.168.1.13:3100/loki/api/v1/push"
+#endif
+#ifndef LOKI_DATA_TYPE_DEFAULT
+#define LOKI_DATA_TYPE_DEFAULT "iot"
+#endif
+#ifndef LOKI_SERVICE_NAME_DEFAULT
+#define LOKI_SERVICE_NAME_DEFAULT "pylontech-battery"
+#endif
+#define ABS_DIFF(a, b) (a > b ? a-b : b-a)
+#define DECL_FIND_OFFSET_OR_FAIL(var, str, key) int var = findOffset((str), (key)); if ((var) == -1) { Log(key " not found"); return false; }
+
+WiFiClient espClient;
+PubSubClient mqttClient(espClient);
+
+char g_szRecvBuff[7000];
+
+ESP8266WebServer server(80);
+SimpleTimer timer;
+circular_log<7000> g_log;
+bool ntpTimeReceived = false;
+int g_baudRate = 0;
+
+void handleLog();
+void handleReq();
+void handleJsonOut();
+void handleRoot();
+void handleSyncTime();
+void handleMetrics();
+void handleMqttPage();
+void handleMqttSave();
+void handleUpdateFinished();
+void handleUpdateUpload();
+void syncTime();
+void wakeUpConsole();
+unsigned long os_getCurrentTimeSec();
+bool parsePwrResponse(const char* pStr);
+bool sendCommandAndReadSerialResponse(const char* command, bool wakeRetry = true, int waitLoops = 150);
+void prepareJsonOutput(char* pBuff, int buffSize);
+void mqttLoop();
+void mqttSetup();
+void loggerLoop();
+void handleLoggerStatus();
+void handleLoggerRun();
+
+void Log(const char* msg)
+{
+  g_log.Log(msg);
+}
+
+void setup() {
+  pinMode(LED_BUILTIN, OUTPUT); 
+  digitalWrite(LED_BUILTIN, HIGH);//high is off
+  
+  // put your setup code here, to run once:
+  WiFi.mode(WIFI_STA);
+  WiFi.persistent(false);
+  WiFi.hostname(WIFI_HOSTNAME);
+  WiFi.begin(WIFI_SSID, WIFI_PASS);
+
+  for(int ix=0; ix<10; ix++)
+  {
+    if(WiFi.status() == WL_CONNECTED)
+    {
+      break;
+    }
+
+    delay(1000);
+  }
+
+  ArduinoOTA.setHostname(OTA_HOSTNAME);
+  ArduinoOTA.begin();
+  server.on("/", handleRoot);
+  server.on("/log", handleLog);
+  server.on("/req", handleReq);
+  server.on("/jsonOut", handleJsonOut);
+  server.on("/metrics", HTTP_GET, handleMetrics);
+  server.on("/sync-time", HTTP_GET, handleSyncTime);
+  server.on("/settings", HTTP_GET, handleMqttPage);
+  server.on("/settings", HTTP_POST, handleMqttSave);
+  server.on("/logger-status", HTTP_GET, handleLoggerStatus);
+  server.on("/logger-run", HTTP_POST, handleLoggerRun);
+  server.on("/update", HTTP_POST, handleUpdateFinished, handleUpdateUpload);
+  server.on("/reboot", [](){
+    ESP.restart();
+  });
+  
+  server.begin(); 
+  
+  mqttSetup();
+  syncTime();
+  wakeUpConsole();
+
+  Log("Boot event");
+}
+
+void handleLog()
+{
+  server.send(200, "text/html", g_log.c_str());
+}
+
+#include "settings.cpp"
+#include "communication.cpp"
+#include "ota.cpp"
+#include "web.cpp"
+#include "mqtt.cpp"
+#include "logger.cpp"
+
+void loop() {
+  ArduinoOTA.handle();
+  server.handleClient();
+  timer.run();
+  mqttLoop();
+  loggerLoop();
+
+  //if there are bytes availbe on serial here - it's unexpected
+  //when we send a command to battery, we read whole response
+  //if we get anything here anyways - we will log it
+  int bytesAv = Serial.available();
+  if(bytesAv > 0)
+  {
+    if(bytesAv > 63)
+    {
+      bytesAv = 63;
+    }
+    
+    char buff[64+4] = "RCV:";
+    if(Serial.readBytes(buff+4, bytesAv) > 0)
+    {
+      digitalWrite(LED_BUILTIN, LOW);
+      delay(5);
+      digitalWrite(LED_BUILTIN, HIGH);//high is off
+
+      Log(buff);
+    }
+  }
+}

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -1,0 +1,162 @@
+// Build a full MQTT topic.
+static String mqttTopic(const char* suffix)
+{
+  String root = mqttSettings.topicRoot;
+  while(root.endsWith("/")) root.remove(root.length() - 1);
+  return root + "/" + MQTT_VALUE_PREFIX + suffix;
+}
+
+// Initialize MQTT.
+void mqttSetup()
+{
+  loadSettings();
+  mqttClient.setServer(mqttSettings.server, mqttSettings.port);
+  mqttClient.setSocketTimeout(1);
+}
+
+// Show device settings.
+void handleMqttPage()
+{
+  String html;
+  html.reserve(5200);
+  html = "<!doctype html><html><meta name='viewport' content='width=device-width'><style>body{font:16px system-ui;background:#f2f4f7;color:#17202a;margin:0}.card{max-width:680px;margin:32px auto;background:white;padding:26px;border-radius:12px;box-shadow:0 3px 18px #0002}h2{margin-top:0}h3{margin:24px 0 8px;color:#345}table{width:100%;border-collapse:collapse}td{padding:9px 4px;border-bottom:1px solid #e5e8eb}td:first-child{width:34%;font-weight:600}input:not([type=checkbox]){box-sizing:border-box;width:100%;padding:9px;border:1px solid #b8c0c8;border-radius:6px;font:inherit}input:focus{outline:2px solid #69c}button{margin-top:22px;background:#1769aa;color:white;border:0;border-radius:7px;padding:11px 24px;font:600 16px system-ui;cursor:pointer}.actions{display:flex;gap:10px;flex-wrap:wrap}.back{float:right;color:#1769aa;text-decoration:none}@media(max-width:720px){.card{margin:0;border-radius:0;padding:20px}td{display:block;width:auto!important;border:0}td:first-child{padding-bottom:2px}}</style><body><main class='card'><a class='back' href='/'>Back</a><h2>Settings</h2><form method='post'><h3>MQTT</h3><table>";
+  html += "<tr><td>Enabled</td><td><label><input type='checkbox' name='enabled' value='1'" + String(mqttSettings.enabled ? " checked" : "") + "> Publish battery data</label></td></tr>";
+  html += "<tr><td>Server</td><td><input name='server' value='" + String(mqttSettings.server) + "'></td></tr>";
+  html += "<tr><td>Port</td><td><input name='port' type='number' min='1' max='65535' value='" + String(mqttSettings.port) + "'></td></tr>";
+  html += "<tr><td>User</td><td><input name='user' value='" + String(mqttSettings.user) + "'></td></tr>";
+  html += "<tr><td>Password</td><td><input name='password' type='password' value='" + String(mqttSettings.password) + "'></td></tr>";
+  html += "<tr><td>Topic root</td><td><input name='topic' value='" + String(mqttSettings.topicRoot) + "'></td></tr>";
+  html += "<tr><td>Refresh interval</td><td><input name='mqttRefresh' type='number' min='1' max='3600' value='" + String(mqttSettings.mqttRefreshSeconds) + "'> seconds</td></tr></table>";
+  html += "<h3>Prometheus</h3><table><tr><td>Namespace</td><td><input name='namespace' value='" + String(mqttSettings.promNamespace) + "'></td></tr>";
+  html += "<tr><td>Free heap</td><td><label><input type='checkbox' name='promFreeHeap' value='1'" + String(mqttSettings.promFreeHeap ? " checked" : "") + "> Include ESP heap metric</label></td></tr></table>";
+  html += "<h3>Time</h3><table><tr><td>NTP server</td><td><input name='ntpServer' value='" + String(mqttSettings.ntpServer) + "'></td></tr></table>";
+  html += "<h3>Loki</h3><table>";
+  html += "<tr><td>Enabled</td><td><label><input type='checkbox' name='lokiEnabled' value='1'" + String(mqttSettings.lokiEnabled ? " checked" : "") + "> Push battery logs</label></td></tr>";
+  html += "<tr><td>Loki URI</td><td><input name='lokiUri' value='" + String(mqttSettings.lokiUri) + "'></td></tr>";
+  html += "<tr><td>Data type</td><td><input name='lokiDataType' value='" + String(mqttSettings.lokiDataType) + "'></td></tr>";
+  html += "<tr><td>Service name</td><td><input name='lokiServiceName' value='" + String(mqttSettings.lokiServiceName) + "'></td></tr>";
+  html += "<tr><td>Device</td><td>Log entry ModID</td></tr></table>";
+  html += F("<h3>Loki status</h3><table><tr><td>State</td><td id='lsState'>Loading...</td></tr><tr><td>Detail</td><td id='lsDetail'>-</td></tr><tr><td>Last attempt</td><td id='lsAttempt'>-</td></tr><tr><td>Next run</td><td id='lsNext'>-</td></tr><tr><td>Events</td><td id='lsEvents'>-</td></tr><tr><td>HTTP status</td><td id='lsHttp'>-</td></tr><tr><td>ESP network</td><td id='lsNetwork'>-</td></tr></table>");
+  html += F("<div class='actions'><button type='button' id='loggerRun'>Run logger now</button><button type='submit'>Save settings</button></div></form></main>");
+  html += F("<script>const q=id=>document.getElementById(id),run=q('loggerRun');async function loggerStatus(){try{let r=await fetch('/logger-status',{cache:'no-store'}),s=await r.json();q('lsState').textContent=s.state;q('lsDetail').textContent=s.detail;q('lsAttempt').textContent=s.last_attempt_ago_s<0?'Never':s.last_attempt_ago_s+'s ago';q('lsNext').textContent=s.next_run_s<0?'Disabled':s.next_run_s+'s';q('lsEvents').textContent=s.events_sent+' sent, '+s.events_skipped+' skipped / '+s.events_found;q('lsHttp').textContent=s.http_status||'-';q('lsNetwork').textContent=s.local_ip+' via '+s.gateway+' | '+s.free_heap+' B heap | '+s.rssi+' dBm'}catch(e){q('lsState').textContent='Status unavailable'}}run.onclick=async()=>{run.disabled=true;q('lsState').textContent='Running...';try{await fetch('/logger-run',{method:'POST'})}catch(e){}run.disabled=false;loggerStatus()};loggerStatus();setInterval(loggerStatus,3000)</script></body></html>");
+  server.send(200, "text/html", html);
+}
+
+// Validate and save settings.
+void handleMqttSave()
+{
+  int port = server.arg("port").toInt();
+  int mqttRefresh = server.arg("mqttRefresh").toInt();
+  bool enabled = server.hasArg("enabled");
+  bool lokiEnabled = server.hasArg("lokiEnabled");
+  bool promFreeHeap = server.hasArg("promFreeHeap");
+  bool invalidLoki = lokiEnabled && (!server.arg("lokiUri").startsWith("http://") || server.arg("lokiDataType").isEmpty() || server.arg("lokiServiceName").isEmpty());
+  if((enabled && server.arg("server").isEmpty()) || port < 1 || port > 65535 || server.arg("namespace").isEmpty() || server.arg("ntpServer").isEmpty() || mqttRefresh < 1 || mqttRefresh > 3600 || invalidLoki)
+  {
+    server.send(400, "text/plain", "Invalid server or port");
+    return;
+  }
+  mqttSettings.enabled = enabled;
+  copySetting(mqttSettings.server, sizeof(mqttSettings.server), server.arg("server"));
+  mqttSettings.port = port;
+  copySetting(mqttSettings.user, sizeof(mqttSettings.user), server.arg("user"));
+  copySetting(mqttSettings.password, sizeof(mqttSettings.password), server.arg("password"));
+  copySetting(mqttSettings.topicRoot, sizeof(mqttSettings.topicRoot), server.arg("topic"));
+  copySetting(mqttSettings.promNamespace, sizeof(mqttSettings.promNamespace), server.arg("namespace"));
+  copySetting(mqttSettings.ntpServer, sizeof(mqttSettings.ntpServer), server.arg("ntpServer"));
+  mqttSettings.mqttRefreshSeconds = mqttRefresh;
+  mqttSettings.lokiEnabled = lokiEnabled;
+  mqttSettings.promFreeHeap = promFreeHeap;
+  copySetting(mqttSettings.lokiUri, sizeof(mqttSettings.lokiUri), server.arg("lokiUri"));
+  copySetting(mqttSettings.lokiDataType, sizeof(mqttSettings.lokiDataType), server.arg("lokiDataType"));
+  copySetting(mqttSettings.lokiServiceName, sizeof(mqttSettings.lokiServiceName), server.arg("lokiServiceName"));
+  if(!saveSettings())
+  {
+    server.send(500, "text/plain", "Save failed");
+    return;
+  }
+  mqttClient.disconnect();
+  mqttClient.setServer(mqttSettings.server, mqttSettings.port);
+  syncTime();
+  server.sendHeader("Location", "/settings");
+  server.send(303);
+}
+
+// Publish a changed float.
+static void mqttPublish(float value, float oldValue, float minDiff, const char* suffix, bool force)
+{
+  if(!force && ABS_DIFF(value, oldValue) <= minDiff) return;
+  char text[16];
+  snprintf(text, sizeof(text), "%.2f", value);
+  mqttClient.publish(mqttTopic(suffix).c_str(), text, false);
+}
+
+// Publish a changed integer.
+static void mqttPublish(long value, long oldValue, long minDiff, const char* suffix, bool force)
+{
+  if(!force && ABS_DIFF(value, oldValue) <= minDiff) return;
+  char text[16];
+  snprintf(text, sizeof(text), "%ld", value);
+  mqttClient.publish(mqttTopic(suffix).c_str(), text, false);
+}
+
+// Publish a changed string.
+static void mqttPublish(const char* value, const char* oldValue, const char* suffix, bool force)
+{
+  if(force || strcmp(value, oldValue) != 0) mqttClient.publish(mqttTopic(suffix).c_str(), value, false);
+}
+
+// Publish battery data.
+static void pushBatteryDataToMqtt(const batteryStack& old, bool force)
+{
+  mqttPublish((float)g_stack.soc, (float)old.soc, 0, "soc", force);
+  mqttPublish(g_stack.temp / 1000.0f, old.temp / 1000.0f, 0, "temp", force);
+  mqttPublish(g_stack.getPowerDC(), old.getPowerDC(), 10, "powerDC", force);
+  mqttPublish(g_stack.getEstPowerAc(), old.getEstPowerAc(), 10, "estPowerAC", force);
+  mqttPublish((long)g_stack.batteryCount, (long)old.batteryCount, 0, "battery_count", force);
+  mqttPublish(g_stack.baseState, old.baseState, "base_state", force);
+  mqttPublish((long)g_stack.isNormal(), (long)old.isNormal(), 0, "is_normal", force);
+}
+
+static unsigned long mqttLastPoll = 0;
+
+// Maintain MQTT and publish data.
+void mqttLoop()
+{
+  if(!mqttSettings.enabled)
+  {
+    if(mqttClient.connected()) mqttClient.disconnect();
+    return;
+  }
+
+  static bool connectAttempted = false;
+  static unsigned long lastConnect = 0;
+  if(mqttSettings.enabled && !mqttClient.connected() && (!connectAttempted || millis() - lastConnect > 60000))
+  {
+    IPAddress address;
+    bool resolved = address.fromString(mqttSettings.server) || WiFi.hostByName(mqttSettings.server, address, 250) == 1;
+    bool transport = resolved && espClient.connect(address, mqttSettings.port);
+    String availability = mqttTopic("availability");
+    if(transport && mqttClient.connect(WIFI_HOSTNAME, mqttSettings.user, mqttSettings.password, availability.c_str(), 1, true, "offline"))
+    {
+      Log("MQTT connected");
+      mqttClient.publish(availability.c_str(), "online", true);
+    }
+    else Log("MQTT connection failed");
+    connectAttempted = true;
+    lastConnect = millis();
+  }
+
+  if(mqttClient.connected() && (!mqttLastPoll || millis() - mqttLastPoll >= mqttSettings.mqttRefreshSeconds * 1000UL))
+  {
+    mqttLastPoll = millis();
+    if(sendCommandAndReadSerialResponse("pwr") && parsePwrResponse(g_szRecvBuff))
+    {
+      static batteryStack old;
+      static unsigned int pollCount = 0;
+      pushBatteryDataToMqtt(old, pollCount++ % 20 == 0);
+      memcpy(&old, &g_stack, sizeof(old));
+    }
+  }
+  if(mqttClient.connected()) mqttClient.loop();
+}

--- a/src/ota.cpp
+++ b/src/ota.cpp
@@ -1,0 +1,64 @@
+static const char OTA_UPDATE_HTML[] PROGMEM = R"HTML(
+<hr><h3>Firmware update</h3>
+<div id="drop" style="border:2px dashed #888;padding:28px;text-align:center;cursor:pointer">Drop <b>firmware.bin</b> here or click<input id="fw" type="file" accept=".bin" hidden></div>
+<progress id="bar" max="100" value="0" style="width:100%;height:22px;margin-top:10px"></progress>
+<div id="status">Waiting for firmware.</div><div id="detail" style="font-family:monospace"></div>
+<ol id="events" style="font-family:monospace;font-size:.9em"></ol>
+<script>
+const d=document.getElementById('drop'),f=document.getElementById('fw'),b=document.getElementById('bar'),s=document.getElementById('status'),v=document.getElementById('detail'),ev=document.getElementById('events');
+let active=false,lastProgress=0,stallTimer;
+const bytes=n=>n<1024?n+' B':n<1048576?(n/1024).toFixed(1)+' KiB':(n/1048576).toFixed(2)+' MiB';
+const duration=n=>!isFinite(n)?'--':n<60?Math.ceil(n)+'s':Math.floor(n/60)+'m '+Math.ceil(n%60)+'s';
+function event(text){let x=document.createElement('li');x.textContent=new Date().toLocaleTimeString()+' - '+text;ev.appendChild(x)}
+function stage(text){s.textContent=text;event(text)}
+d.onclick=()=>!active&&f.click();d.ondragover=e=>{e.preventDefault();d.style.borderColor='#06c'};d.ondragleave=()=>d.style.borderColor='#888';
+d.ondrop=e=>{e.preventDefault();d.style.borderColor='#888';if(!active)upload(e.dataTransfer.files[0])};f.onchange=()=>upload(f.files[0]);
+function upload(file){
+ if(!file)return;if(!file.name.toLowerCase().endsWith('.bin')){stage('Rejected: select a .bin firmware file.');return}
+ active=true;b.value=0;v.textContent='';ev.innerHTML='';d.style.opacity='.55';
+ let form=new FormData(),xhr=new XMLHttpRequest(),start=performance.now(),lastTime=start,lastBytes=0,speed=0,stalled=false;
+ form.append('firmware',file,file.name);stage('Preparing '+file.name+' ('+bytes(file.size)+')');
+ xhr.open('POST','/update');xhr.timeout=600000;lastProgress=Date.now();
+ stallTimer=setInterval(()=>{if(active&&Date.now()-lastProgress>5000&&!stalled){stalled=true;event('Warning: no upload progress for 5 seconds. Still waiting...')}},1000);
+ xhr.upload.onloadstart=()=>stage('Uploading firmware to device...');
+ xhr.upload.onprogress=e=>{if(!e.lengthComputable)return;let now=performance.now(),dt=(now-lastTime)/1000,instant=dt?(e.loaded-lastBytes)/dt:0;speed=speed?speed*.7+instant*.3:instant;lastTime=now;lastBytes=e.loaded;lastProgress=Date.now();stalled=false;let pct=e.loaded/e.total*100;b.value=pct;v.textContent=pct.toFixed(1)+'% | '+bytes(e.loaded)+' / '+bytes(e.total)+' | '+bytes(Math.round(speed))+'/s | ETA '+duration((e.total-e.loaded)/speed)+' | elapsed '+duration((now-start)/1000)};
+ xhr.upload.onload=()=>{b.value=100;stage('Upload received. Device is validating and finalizing...')};
+ xhr.onload=()=>{finish();if(xhr.status>=200&&xhr.status<300){stage(xhr.responseText||'Update complete. Rebooting...');waitForDevice(20)}else stage('Update failed: '+(xhr.responseText||('HTTP '+xhr.status)))};
+ xhr.onerror=()=>{finish();stage('Connection lost during update. Check whether the device rebooted.')};xhr.ontimeout=()=>{finish();stage('Update timed out after 10 minutes.')};xhr.onabort=()=>{finish();stage('Update cancelled.')};xhr.send(form);
+ function finish(){active=false;clearInterval(stallTimer);d.style.opacity='1'}
+}
+function waitForDevice(left){if(!left){event('Device did not return yet. Reload manually.');return}stage('Rebooting; checking device ('+left+' attempts left)...');setTimeout(()=>fetch('/',{cache:'no-store'}).then(r=>{if(r.ok){event('Device is back online. Reloading...');setTimeout(()=>location.reload(),800)}else throw 0}).catch(()=>waitForDevice(left-1)),1500)}
+</script>
+)HTML";
+
+void handleUpdateUpload()
+{
+  HTTPUpload& upload = server.upload();
+  if(upload.status == UPLOAD_FILE_START)
+  {
+    WiFiUDP::stopAll();
+    if(!Update.begin((ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000)) Log("OTA: not enough space");
+  }
+  else if(upload.status == UPLOAD_FILE_WRITE)
+  {
+    if(Update.write(upload.buf, upload.currentSize) != upload.currentSize) Log("OTA: write failed");
+  }
+  else if(upload.status == UPLOAD_FILE_END)
+  {
+    if(!Update.end(true)) Log("OTA: finalize failed");
+  }
+  yield();
+}
+
+void handleUpdateFinished()
+{
+  bool ok = !Update.hasError();
+  server.sendHeader("Connection", "close");
+  server.send(ok ? 200 : 500, "text/plain", ok ? "Update complete. Rebooting..." : "Update failed.");
+  if(ok)
+  {
+    delay(250);
+    ESP.restart();
+  }
+}
+

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,0 +1,141 @@
+#include <LittleFS.h>
+
+struct MqttSettings
+{
+  bool enabled;
+  char server[64];
+  uint16_t port;
+  char user[40];
+  char password[64];
+  char topicRoot[96];
+  char promNamespace[32];
+  uint16_t mqttRefreshSeconds;
+  char ntpServer[64];
+  bool lokiEnabled;
+  char lokiUri[128];
+  char lokiDataType[32];
+  char lokiServiceName[48];
+  bool promFreeHeap;
+};
+
+MqttSettings mqttSettings;
+
+// Copy a setting safely.
+static void copySetting(char *out, size_t size, const String &value)
+{
+  String clean = value;
+  clean.trim();
+  strlcpy(out, clean.c_str(), size);
+}
+
+// Restore defaults.
+static void settingsDefaults()
+{
+  mqttSettings.enabled = MQTT_ENABLED_DEFAULT != 0;
+  copySetting(mqttSettings.server, sizeof(mqttSettings.server), MQTT_SERVER_DEFAULT);
+  mqttSettings.port = MQTT_PORT_DEFAULT;
+  copySetting(mqttSettings.user, sizeof(mqttSettings.user), MQTT_USER_DEFAULT);
+  copySetting(mqttSettings.password, sizeof(mqttSettings.password), MQTT_PASSWORD_DEFAULT);
+  copySetting(mqttSettings.topicRoot, sizeof(mqttSettings.topicRoot), MQTT_TOPIC_ROOT_DEFAULT);
+  copySetting(mqttSettings.promNamespace, sizeof(mqttSettings.promNamespace), "devicemon");
+  mqttSettings.mqttRefreshSeconds = 10;
+  copySetting(mqttSettings.ntpServer, sizeof(mqttSettings.ntpServer), NTP_SERVER_DEFAULT);
+  mqttSettings.lokiEnabled = LOKI_ENABLED_DEFAULT != 0;
+  copySetting(mqttSettings.lokiUri, sizeof(mqttSettings.lokiUri), LOKI_URI_DEFAULT);
+  copySetting(mqttSettings.lokiDataType, sizeof(mqttSettings.lokiDataType), LOKI_DATA_TYPE_DEFAULT);
+  copySetting(mqttSettings.lokiServiceName, sizeof(mqttSettings.lokiServiceName), LOKI_SERVICE_NAME_DEFAULT);
+  mqttSettings.promFreeHeap = PROM_FREE_HEAP_DEFAULT != 0;
+}
+
+// Mount persistent storage.
+static bool mountSettingsFs()
+{
+  return LittleFS.begin() || (LittleFS.format() && LittleFS.begin());
+}
+
+// Read settings from a file.
+static bool readSettings(const char *path)
+{
+  File file = LittleFS.open(path, "r");
+  if (!file)
+    return false;
+  mqttSettings.enabled = file.readStringUntil('\n').toInt() != 0;
+  copySetting(mqttSettings.server, sizeof(mqttSettings.server), file.readStringUntil('\n'));
+  mqttSettings.port = file.readStringUntil('\n').toInt();
+  copySetting(mqttSettings.user, sizeof(mqttSettings.user), file.readStringUntil('\n'));
+  copySetting(mqttSettings.password, sizeof(mqttSettings.password), file.readStringUntil('\n'));
+  copySetting(mqttSettings.topicRoot, sizeof(mqttSettings.topicRoot), file.readStringUntil('\n'));
+  String promNamespace = file.readStringUntil('\n');
+  if (promNamespace.length())
+    copySetting(mqttSettings.promNamespace, sizeof(mqttSettings.promNamespace), promNamespace);
+  int mqttRefresh = file.readStringUntil('\n').toInt();
+  if (mqttRefresh > 0) mqttSettings.mqttRefreshSeconds = mqttRefresh;
+  String ntpServer = file.readStringUntil('\n');
+  if (ntpServer.length()) copySetting(mqttSettings.ntpServer, sizeof(mqttSettings.ntpServer), ntpServer);
+  String lokiEnabled = file.readStringUntil('\n');
+  if (lokiEnabled.length()) mqttSettings.lokiEnabled = lokiEnabled.toInt() != 0;
+  String lokiUri = file.readStringUntil('\n');
+  if (lokiUri.length()) copySetting(mqttSettings.lokiUri, sizeof(mqttSettings.lokiUri), lokiUri);
+  String lokiDataType = file.readStringUntil('\n');
+  if (lokiDataType.length()) copySetting(mqttSettings.lokiDataType, sizeof(mqttSettings.lokiDataType), lokiDataType);
+  String lokiServiceName = file.readStringUntil('\n');
+  if (lokiServiceName.length()) copySetting(mqttSettings.lokiServiceName, sizeof(mqttSettings.lokiServiceName), lokiServiceName);
+  String promFreeHeap = file.readStringUntil('\n');
+  if (promFreeHeap.length()) mqttSettings.promFreeHeap = promFreeHeap.toInt() != 0;
+  file.close();
+  return true;
+}
+
+// Save settings to flash.
+bool saveSettings()
+{
+  File file = LittleFS.open("/settings.cfg", "w");
+  if (!file)
+    return false;
+  file.println(mqttSettings.enabled ? 1 : 0);
+  file.println(mqttSettings.server);
+  file.println(mqttSettings.port);
+  file.println(mqttSettings.user);
+  file.println(mqttSettings.password);
+  file.println(mqttSettings.topicRoot);
+  file.println(mqttSettings.promNamespace);
+  file.println(mqttSettings.mqttRefreshSeconds);
+  file.println(mqttSettings.ntpServer);
+  file.println(mqttSettings.lokiEnabled ? 1 : 0);
+  file.println(mqttSettings.lokiUri);
+  file.println(mqttSettings.lokiDataType);
+  file.println(mqttSettings.lokiServiceName);
+  file.println(mqttSettings.promFreeHeap ? 1 : 0);
+  file.close();
+  return true;
+}
+
+// Read the newest forwarded log fingerprint.
+bool loadLoggerFingerprint(uint32_t& fingerprint)
+{
+  File file = LittleFS.open("/logger.idx", "r");
+  if(!file) return false;
+  fingerprint = strtoul(file.readStringUntil('\n').c_str(), NULL, 16);
+  file.close();
+  return true;
+}
+
+// Save the newest forwarded log fingerprint.
+bool saveLoggerFingerprint(uint32_t fingerprint)
+{
+  File file = LittleFS.open("/logger.idx", "w");
+  if(!file) return false;
+  file.printf("%08lx\n", (unsigned long)fingerprint);
+  file.close();
+  return true;
+}
+
+// Load settings
+void loadSettings()
+{
+  settingsDefaults();
+  if (!mountSettingsFs())
+    return;
+  if (readSettings("/settings.cfg"))
+    return;
+}

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -1,0 +1,559 @@
+void handleReq()
+{
+  bool respOK;
+  if(server.hasArg("code") == false)
+  {
+    respOK = sendCommandAndReadSerialResponse("");
+  }
+  else
+  {
+    respOK = sendCommandAndReadSerialResponse(server.arg("code").c_str());
+  }
+
+  if(respOK)
+  {
+    server.send(200, "text/plain", g_szRecvBuff);
+  }
+  else
+  {
+    server.send(500, "text/plain", "????");
+  }
+}
+
+void handleJsonOut()
+{
+  if(sendCommandAndReadSerialResponse("pwr") == false)
+  {
+    server.send(500, "text/plain", "Failed to get response to 'pwr' command");
+    return;
+  }
+
+  parsePwrResponse(g_szRecvBuff);
+  prepareJsonOutput(g_szRecvBuff, sizeof(g_szRecvBuff));
+  server.send(200, "application/json", g_szRecvBuff);
+}
+
+static time_t berlinTime(time_t utc, const char*& zone)
+{
+  tmElements_t parts;
+  breakTime(utc, parts);
+  tmElements_t boundary = {};
+  boundary.Year = parts.Year;
+  boundary.Month = 3;
+  boundary.Day = 31;
+  boundary.Hour = 1;
+  time_t march = makeTime(boundary);
+  boundary.Day = 31 - (weekday(march) - 1);
+  time_t summerStart = makeTime(boundary);
+  boundary.Month = 10;
+  boundary.Day = 31;
+  time_t october = makeTime(boundary);
+  boundary.Day = 31 - (weekday(october) - 1);
+  time_t summerEnd = makeTime(boundary);
+  bool summer = utc >= summerStart && utc < summerEnd;
+  zone = summer ? "MESZ" : "MEZ";
+  return utc + (summer ? 7200 : 3600);
+}
+
+static bool readBatteryTime(char* output, size_t outputSize)
+{
+  if(!sendCommandAndReadSerialResponse("time")) return false;
+  const char* value = strstr(g_szRecvBuff, "RTC ");
+  if(!value) return false;
+  value += 4;
+  const char* end = strpbrk(value, "\r\n");
+  size_t length = end ? (size_t)(end - value) : strlen(value);
+  length = min(length, outputSize - 1);
+  memcpy(output, value, length);
+  output[length] = 0;
+  return true;
+}
+
+void handleSyncTime()
+{
+  const char* names[] = {"epoch", "year", "month", "day", "hour", "minute", "second"};
+  for(const char* name : names)
+  {
+    if(!server.hasArg(name))
+    {
+      server.send(400, "text/plain", "Missing time value.");
+      return;
+    }
+  }
+
+  unsigned long epoch = strtoul(server.arg("epoch").c_str(), NULL, 10);
+  int yearValue = server.arg("year").toInt();
+  int monthValue = server.arg("month").toInt();
+  int dayValue = server.arg("day").toInt();
+  int hourValue = server.arg("hour").toInt();
+  int minuteValue = server.arg("minute").toInt();
+  int secondValue = server.arg("second").toInt();
+  if(epoch < 946684800UL || yearValue < 2000 || yearValue > 2099 || monthValue < 1 || monthValue > 12 || dayValue < 1 || dayValue > 31 || hourValue < 0 || hourValue > 23 || minuteValue < 0 || minuteValue > 59 || secondValue < 0 || secondValue > 59)
+  {
+    server.send(400, "text/plain", "Invalid time value.");
+    return;
+  }
+
+  char command[64];
+  snprintf(command, sizeof(command), "time %02d %02d %02d %02d %02d %02d", yearValue % 100, monthValue, dayValue, hourValue, minuteValue, secondValue);
+  if(!sendCommandAndReadSerialResponse(command) || strstr(g_szRecvBuff, "Command completed successfully") == NULL)
+  {
+    server.send(502, "text/plain", "Battery time sync failed.");
+    return;
+  }
+
+  setTime((time_t)epoch);
+  ntpTimeReceived = true;
+  server.sendHeader("Location", "/");
+  server.send(303);
+}
+
+void handleRoot() {
+  unsigned long days = 0, hours = 0, minutes = 0;
+  unsigned long val = os_getCurrentTimeSec();
+  
+  days = val / (3600*24);
+  val -= days * (3600*24);
+  
+  hours = val / 3600;
+  val -= hours * 3600;
+  
+  minutes = val / 60;
+  val -= minutes*60;
+  
+  char batteryTime[24] = "Unavailable";
+  readBatteryTime(batteryTime, sizeof(batteryTime));
+  const char* zone = "";
+  time_t localTime = berlinTime(now(), zone);
+  tmElements_t local;
+  breakTime(localTime, local);
+
+  static char szTmp[5000] = "";
+  snprintf(szTmp, sizeof(szTmp)-1, "<html><b>Garage Battery</b><br>ESP time: %d/%02d/%02d %02d:%02d:%02d (%s, Europe/Berlin)<br>Battery time: %s<br><button type='button' onclick='syncTimes(this)'>Sync ESP + battery to PC time</button> <span id='syncStatus'></span><script>async function syncTimes(b){let d=new Date(),q=new URLSearchParams({epoch:Math.floor(Date.now()/1000),year:d.getFullYear(),month:d.getMonth()+1,day:d.getDate(),hour:d.getHours(),minute:d.getMinutes(),second:d.getSeconds()}),s=document.getElementById('syncStatus');b.disabled=true;s.textContent=' Syncing...';try{let r=await fetch('/sync-time?'+q);if(!r.ok)throw new Error(await r.text());location.reload()}catch(e){s.textContent=' '+e.message;b.disabled=false}}</script><br>Uptime: %02d:%02d:%02d.%02d<br><br>free heap: %u<br>Wifi RSSI: %d<BR>Wifi SSID: %s",
+            tmYearToCalendar(local.Year), local.Month, local.Day, local.Hour, local.Minute, local.Second, zone, batteryTime,
+            (int)days, (int)hours, (int)minutes, (int)val, 
+            ESP.getFreeHeap(), WiFi.RSSI(), WiFi.SSID().c_str());
+
+
+  strncat(szTmp, "<BR><a href='/log'>Runtime log</a> | <a href='/metrics'>Prometheus metrics</a> | <a href='/settings'>Settings</a><HR>", sizeof(szTmp)-1);
+  strncat(szTmp, "<form action='/req' method='get'>Command:<input type='text' name='code'/><input type='submit'></form><a href='/req?code=pwr'>Power</a> | <a href='/req?code=help'>Help</a> | <a href='/req?code=log'>Event Log</a> | <a href='/req?code=time'>Time</a>", sizeof(szTmp)-1);
+  server.setContentLength(CONTENT_LENGTH_UNKNOWN);
+  server.send(200, "text/html", szTmp);
+  server.sendContent_P(OTA_UPDATE_HTML);
+  server.sendContent("</html>");
+  server.sendContent("");
+}
+
+void prepareJsonOutput(char* pBuff, int buffSize)
+{
+  memset(pBuff, 0, buffSize);
+  snprintf(pBuff, buffSize-1, "{\"soc\": %d, \"temp\": %d, \"currentDC\": %ld, \"avgVoltage\": %ld, \"baseState\": \"%s\", \"batteryCount\": %d, \"powerDC\": %ld, \"estPowerAC\": %ld, \"isNormal\": %s}", g_stack.soc, 
+                                                                                                                                                                                                            g_stack.temp, 
+                                                                                                                                                                                                            g_stack.currentDC, 
+                                                                                                                                                                                                            g_stack.avgVoltage, 
+                                                                                                                                                                                                            g_stack.baseState, 
+                                                                                                                                                                                                            g_stack.batteryCount, 
+                                                                                                                                                                                                            g_stack.getPowerDC(), 
+                                                                                                                                                                                                            g_stack.getEstPowerAc(),
+                                                                                                                                                                                                            g_stack.isNormal() ? "true" : "false");
+}
+
+static int prometheusState(const char* state)
+{
+  if(strcmp(state, "Charge") == 0) return 0;
+  if(strcmp(state, "Dischg") == 0) return 1;
+  if(strcmp(state, "Idle") == 0) return 2;
+  if(strcmp(state, "Balance") == 0) return 3;
+  return -1;
+}
+
+struct BatteryMetricRecord
+{
+  uint8_t unit;
+  uint8_t id;
+  int32_t volt;
+  int32_t curr;
+  int32_t temp;
+  int32_t coulomb;
+  int16_t soc;
+  int8_t baseState;
+  uint8_t balanceCount;
+};
+
+struct StatUnitRecord
+{
+  bool hasCycles;
+  bool hasSoh;
+  bool hasDsgCap;
+  float cycles;
+  float soh;
+  float dsgCap;
+};
+
+struct StatRangeRecord
+{
+  uint8_t unit;
+  uint8_t family;
+  char range[16];
+  float value;
+};
+
+static BatteryMetricRecord batteryRecords[MAX_BATTERY_METRIC_ROWS];
+static StatUnitRecord statUnits[MAX_PYLON_BATTERIES];
+static StatRangeRecord statRanges[MAX_STAT_RANGE_METRICS];
+static size_t batteryRecordCount;
+static size_t statRangeCount;
+static bool statCacheValid;
+static unsigned long statLastFetch;
+
+class MetricWriter
+{
+public:
+  MetricWriter() : used(0) {}
+
+  void printf(const char* format, ...)
+  {
+    char line[320];
+    va_list args;
+    va_start(args, format);
+    int length = vsnprintf(line, sizeof(line), format, args);
+    va_end(args);
+    if(length <= 0) return;
+    size_t bytes = min((size_t)length, sizeof(line) - 1);
+    if(used + bytes > sizeof(buffer)) flush();
+    if(bytes > sizeof(buffer))
+    {
+      server.sendContent(line, bytes);
+      delay(1);
+      return;
+    }
+    memcpy(buffer + used, line, bytes);
+    used += bytes;
+  }
+
+  void finish()
+  {
+    flush();
+  }
+
+private:
+  void flush()
+  {
+    if(used)
+    {
+      server.sendContent(buffer, used);
+      used = 0;
+      delay(1);
+    }
+  }
+
+  size_t used;
+  char buffer[METRICS_SEND_BUFFER_SIZE];
+};
+
+static char* trimText(char* text)
+{
+  while(isspace((unsigned char)*text)) ++text;
+  char* end = text + strlen(text);
+  while(end > text && isspace((unsigned char)end[-1])) --end;
+  *end = 0;
+  return text;
+}
+
+static bool collectBatteryMetrics(int unit)
+{
+  char* lineSave = NULL;
+  for(char* line = strtok_r(g_szRecvBuff, "\r\n", &lineSave); line; line = strtok_r(NULL, "\r\n", &lineSave))
+  {
+    char* fields[16];
+    int count = 0;
+    char* fieldSave = NULL;
+    for(char* field = strtok_r(line, " \t", &fieldSave); field && count < 16; field = strtok_r(NULL, " \t", &fieldSave)) fields[count++] = field;
+    if(count < 12 || !isdigit((unsigned char)fields[0][0]) || !isdigit((unsigned char)fields[1][0])) continue;
+    if(batteryRecordCount >= MAX_BATTERY_METRIC_ROWS) return false;
+
+    BatteryMetricRecord& record = batteryRecords[batteryRecordCount++];
+    record.unit = unit;
+    record.id = atoi(fields[0]);
+    record.volt = atol(fields[1]);
+    record.curr = atol(fields[2]);
+    record.temp = atol(fields[3]);
+    record.baseState = prometheusState(fields[4]);
+    record.soc = atoi(fields[8]);
+    record.coulomb = atol(fields[9]);
+    record.balanceCount = strcmp(fields[11], "Y") == 0 ? 1 : 0;
+    if(strcmp(fields[11], "N") != 0 && strcmp(fields[11], "Y") != 0)
+      for(const char* p = fields[11]; *p; ++p) if(*p == '1') ++record.balanceCount;
+  }
+  return true;
+}
+
+static void normalizeRange(const char* input, char* output, size_t outputSize)
+{
+  char clean[24] = "";
+  size_t used = 0;
+  for(size_t i=0; input[i] && used + 1 < sizeof(clean); ++i)
+  {
+    char c = tolower((unsigned char)input[i]);
+    if(isspace((unsigned char)c) || c == '%') continue;
+    if(c == '~' || c == '_') c = '-';
+    if(c == 't' && tolower((unsigned char)input[i + 1]) == 'o') { c = '-'; ++i; }
+    clean[used++] = c;
+  }
+  clean[used] = 0;
+
+  char* start = clean;
+  while(*start == '-' || *start == ':') ++start;
+  size_t length = strlen(start);
+  while(length && (start[length - 1] == '-' || start[length - 1] == ':')) start[--length] = 0;
+  if(length >= 5 && strcmp(start + length - 5, "above") == 0)
+  {
+    start[length - 5] = 0;
+    strlcpy(output, "gt", outputSize);
+    strlcat(output, start, outputSize);
+  }
+  else if(strncmp(start, "above", 5) == 0)
+  {
+    strlcpy(output, "gt", outputSize);
+    strlcat(output, start + 5, outputSize);
+  }
+  else if(length && start[length - 1] == '+')
+  {
+    start[length - 1] = 0;
+    strlcpy(output, "gt", outputSize);
+    strlcat(output, start, outputSize);
+  }
+  else strlcpy(output, start, outputSize);
+}
+
+static bool storeStatRange(int unit, int family, const char* range, float value)
+{
+  for(size_t i=0; i<statRangeCount; ++i)
+  {
+    if(statRanges[i].unit == unit && statRanges[i].family == family && strcmp(statRanges[i].range, range) == 0)
+    {
+      statRanges[i].value = value;
+      return true;
+    }
+  }
+  if(statRangeCount >= MAX_STAT_RANGE_METRICS) return false;
+  StatRangeRecord& record = statRanges[statRangeCount++];
+  record.unit = unit;
+  record.family = family;
+  strlcpy(record.range, range, sizeof(record.range));
+  record.value = value;
+  return true;
+}
+
+static bool collectStatMetrics(int unit, bool& parsed)
+{
+  parsed = false;
+  StatUnitRecord& stat = statUnits[unit - 1];
+  char* save = NULL;
+  for(char* line = strtok_r(g_szRecvBuff, "\r\n", &save); line; line = strtok_r(NULL, "\r\n", &save))
+  {
+    char* colon = strchr(line, ':');
+    if(!colon) continue;
+    *colon = 0;
+    char* label = trimText(line);
+    char* valueStart = trimText(colon + 1);
+    char* valueEnd = NULL;
+    float value = strtod(valueStart, &valueEnd);
+    if(valueEnd == valueStart) continue;
+
+    if(strcasecmp(label, "Cycle Times") == 0 || strcasecmp(label, "Cycles") == 0) { stat.cycles = value; stat.hasCycles = true; parsed = true; continue; }
+    if(strcasecmp(label, "SOH") == 0) { stat.soh = value; stat.hasSoh = true; parsed = true; continue; }
+    if(strcasecmp(label, "Dsg Cap") == 0) { stat.dsgCap = value; stat.hasDsgCap = true; parsed = true; continue; }
+
+    size_t labelLength = strlen(label);
+    size_t suffixLength = 0;
+    if(labelLength >= 5 && strcasecmp(label + labelLength - 5, " Secs") == 0) suffixLength = 5;
+    else if(labelLength >= 4 && strcasecmp(label + labelLength - 4, " Sec") == 0) suffixLength = 4;
+    if(!suffixLength) continue;
+    label[labelLength - suffixLength] = 0;
+
+    int family = -1;
+    const char* rawRange = NULL;
+    if(strncasecmp(label, "ChgCurr ", 8) == 0) { family = 0; rawRange = label + 8; }
+    else if(strncasecmp(label, "DsgCurr ", 8) == 0) { family = 1; rawRange = label + 8; }
+    else if(strncasecmp(label, "Soc ", 4) == 0) { family = 2; rawRange = label + 4; }
+    if(family < 0) continue;
+
+    char range[16];
+    normalizeRange(rawRange, range, sizeof(range));
+    if(family == 2 && strcmp(range, "0-20") != 0 && strcmp(range, "20-60") != 0 && strcmp(range, "gt60") != 0) continue;
+    if(!storeStatRange(unit, family, range, value)) return false;
+    parsed = true;
+  }
+  return true;
+}
+
+static void emitHeader(MetricWriter& output, const char* subsystem, const char* name, const char* help)
+{
+  output.printf("# HELP %s_%s_%s %s\n", mqttSettings.promNamespace, subsystem, name, help);
+  output.printf("# TYPE %s_%s_%s gauge\n", mqttSettings.promNamespace, subsystem, name);
+}
+
+static void emitPowerFamily(MetricWriter& output, int family, const char* name, const char* help)
+{
+  bool hasValues = false;
+  for(int i=0; i<MAX_PYLON_BATTERIES; ++i)
+    if(g_stack.batts[i].isPresent && (family != 5 || g_stack.batts[i].mosTempr[0])) { hasValues = true; break; }
+  if(!hasValues) return;
+  emitHeader(output, "power", name, help);
+  for(int i=0; i<MAX_PYLON_BATTERIES; ++i)
+  {
+    const pylonBattery& battery = g_stack.batts[i];
+    if(!battery.isPresent || (family == 5 && !battery.mosTempr[0])) continue;
+    double value = family == 0 ? battery.voltage :
+                   family == 1 ? battery.current :
+                   family == 2 ? battery.tempr / 1000.0 :
+                   family == 3 ? prometheusState(battery.baseState) :
+                   family == 4 ? battery.soc : atof(battery.mosTempr) / 10.0;
+    output.printf("%s_power_%s{id=\"%d\"} %.6f\n", mqttSettings.promNamespace, name, i + 1, value);
+  }
+}
+
+static void emitBatteryFamily(MetricWriter& output, int family, const char* name, const char* help)
+{
+  if(!batteryRecordCount) return;
+  emitHeader(output, "battery", name, help);
+  for(size_t i=0; i<batteryRecordCount; ++i)
+  {
+    const BatteryMetricRecord& record = batteryRecords[i];
+    double value = family == 0 ? record.volt :
+                   family == 1 ? record.curr :
+                   family == 2 ? record.temp / 1000.0 :
+                   family == 3 ? record.baseState :
+                   family == 4 ? record.soc :
+                   family == 5 ? record.coulomb : record.balanceCount;
+    output.printf("%s_battery_%s{unit=\"bat%d\",id=\"%d\"} %.6f\n", mqttSettings.promNamespace, name, record.unit, record.id, value);
+  }
+}
+
+static void emitStatUnitFamily(MetricWriter& output, int family, const char* name, const char* help, int units)
+{
+  bool hasValues = false;
+  for(int unit=0; unit<units; ++unit)
+    if((family == 0 && statUnits[unit].hasCycles) || (family == 1 && statUnits[unit].hasSoh) || (family == 2 && statUnits[unit].hasDsgCap)) { hasValues = true; break; }
+  if(!hasValues) return;
+  emitHeader(output, "battery_stat", name, help);
+  for(int unit=0; unit<units; ++unit)
+  {
+    const StatUnitRecord& stat = statUnits[unit];
+    bool present = family == 0 ? stat.hasCycles : family == 1 ? stat.hasSoh : stat.hasDsgCap;
+    if(!present) continue;
+    double value = family == 0 ? stat.cycles : family == 1 ? stat.soh : stat.dsgCap;
+    output.printf("%s_battery_stat_%s{unit=\"bat%d\"} %.6f\n", mqttSettings.promNamespace, name, unit + 1, value);
+  }
+}
+
+static void emitStatRangeFamily(MetricWriter& output, int family, const char* name, const char* help, const char* rangeLabel)
+{
+  bool hasValues = false;
+  for(size_t i=0; i<statRangeCount; ++i) if(statRanges[i].family == family) { hasValues = true; break; }
+  if(!hasValues) return;
+  emitHeader(output, "battery_stat", name, help);
+  for(size_t i=0; i<statRangeCount; ++i)
+  {
+    const StatRangeRecord& record = statRanges[i];
+    if(record.family != family) continue;
+    output.printf("%s_battery_stat_%s{unit=\"bat%d\",%s=\"%s\"} %.6f\n", mqttSettings.promNamespace, name, record.unit, rangeLabel, record.range, (double)record.value);
+  }
+}
+
+static void emitAllMetrics(MetricWriter& output)
+{
+  if(mqttSettings.promFreeHeap)
+  {
+    output.printf("# HELP %s_esp_free_heap_bytes ESP8266 free heap in bytes.\n", mqttSettings.promNamespace);
+    output.printf("# TYPE %s_esp_free_heap_bytes gauge\n", mqttSettings.promNamespace);
+    output.printf("%s_esp_free_heap_bytes %u\n", mqttSettings.promNamespace, ESP.getFreeHeap());
+  }
+  emitPowerFamily(output, 0, "volt", "Power supply voltage in millivolts.");
+  emitPowerFamily(output, 1, "curr", "Power supply current in milliamps.");
+  emitPowerFamily(output, 2, "temp_celsius", "Power supply board temperature in degrees Celsius. Assumes input is milli-degrees C.");
+  emitPowerFamily(output, 3, "base_state", "Power supply base state code (e.g., 0: Charge, 1: Dischg, 2: Idle, -1: N/A).");
+  emitPowerFamily(output, 4, "soc_percent", "Power supply State of Charge or equivalent percentage (from 'Coulomb' field).");
+  emitPowerFamily(output, 5, "mos_temp_celsius", "Power supply MOS temperature in degrees Celsius. Assumes input is milli-degrees C if numeric.");
+  emitBatteryFamily(output, 0, "volt", "Battery voltage in millivolts.");
+  emitBatteryFamily(output, 1, "curr", "Battery current in milliamps.");
+  emitBatteryFamily(output, 2, "temp_celsius", "Battery temperature in degrees Celsius. Assumes input is milli-degrees C (e.g., 17000 -> 17.0 C).");
+  emitBatteryFamily(output, 3, "base_state", "Battery base state code (0: Charge, 1: Dischg, 2: Idle, 3: Balance, -1: Unknown).");
+  emitBatteryFamily(output, 4, "soc", "Battery State of Charge in percent.");
+  emitBatteryFamily(output, 5, "coulomb", "Battery remaining capacity in milliampere-hours.");
+  emitBatteryFamily(output, 6, "bal_active_count", "Number of active balancing channels. If BAL is 'N' or similar, this will be 0.");
+  emitStatUnitFamily(output, 0, "cycles", "Battery cycle count from stat output.", MAX_PYLON_BATTERIES);
+  emitStatUnitFamily(output, 1, "soh_percent", "Battery state of health in percent from stat output.", MAX_PYLON_BATTERIES);
+  emitStatUnitFamily(output, 2, "dsg_cap", "Cumulative discharge capacity from stat output, in the device's reported units.", MAX_PYLON_BATTERIES);
+  emitStatRangeFamily(output, 0, "chg_curr_secs", "Charge current seconds by current range from stat output.", "current_range");
+  emitStatRangeFamily(output, 1, "dsg_curr_secs", "Discharge current seconds by current range from stat output.", "current_range");
+  emitStatRangeFamily(output, 2, "soc_secs", "SOC seconds by SOC range (0-20, 20-60, gt60) from stat output.", "soc_range");
+}
+
+void handleMetrics()
+{
+  batteryRecordCount = 0;
+
+  bool pwrReceived = sendCommandAndReadSerialResponse("pwr");
+  if(!pwrReceived || !parsePwrResponse(g_szRecvBuff))
+  {
+    String error = pwrReceived ? "PWR response could not be parsed:\n" : "No PWR response received.\n";
+    if(pwrReceived) error += g_szRecvBuff;
+    server.send(502, "text/plain", error);
+    return;
+  }
+
+  int units = g_stack.batteryCount;
+  for(int unit=1; unit<=units; ++unit)
+  {
+    char command[20]; snprintf(command, sizeof(command), "bat %d", unit);
+    if(!sendCommandAndReadSerialResponse(command, false, METRICS_COMMAND_WAIT_LOOPS))
+    {
+      char message[40]; snprintf(message, sizeof(message), "Metrics: %s failed", command);
+      Log(message);
+      continue;
+    }
+    if(!collectBatteryMetrics(unit))
+    {
+      server.send(502, "text/plain", "Too many BAT rows.\n");
+      return;
+    }
+  }
+  if(!statCacheValid || millis() - statLastFetch >= STAT_REFRESH_INTERVAL_MS)
+  {
+    bool refreshed = false;
+    for(int unit=1; unit<=units; ++unit)
+    {
+      char command[20]; snprintf(command, sizeof(command), "stat %d", unit);
+      if(!sendCommandAndReadSerialResponse(command, false, METRICS_COMMAND_WAIT_LOOPS))
+      {
+        char message[40]; snprintf(message, sizeof(message), "Metrics: %s failed", command);
+        Log(message);
+        continue;
+      }
+      bool parsed = false;
+      if(!collectStatMetrics(unit, parsed))
+      {
+        server.send(502, "text/plain", "Too many STAT rows.\n");
+        return;
+      }
+      refreshed |= parsed;
+    }
+    if(refreshed)
+    {
+      statCacheValid = true;
+      statLastFetch = millis();
+    }
+  }
+
+  server.setContentLength(CONTENT_LENGTH_UNKNOWN);
+  server.client().setSync(true);
+  Log("Metrics: send");
+  server.send(200, "text/plain; version=0.0.4; charset=utf-8", "");
+  MetricWriter response;
+  emitAllMetrics(response);
+  response.finish();
+  server.sendContent("");
+  Log("Metrics: done");
+}


### PR DESCRIPTION
- Added OTA via Web
- Added Timesync
- Added Settingspage
- Added Prometheus Metrics
- Added Loki support

Moved to platformIO

Why Loki? 
My battery's randomly went into a error state, however the BMS only stores last 32 entry so i could never actually see what the error was. Now logs are pushed to a Loki instance to get a longer history.

The metric pages includes all information for current operation and monitoring of battery decay.
Charging C means AH/Amps and is a value pylontech recommends to always stay below 1
SoC State (key: devicemon_battery_stat_soc_secs) gives the time spend at each SoC, staying at high values for a long time can speed up decay.
The BMS keeps a counter of discharge (devicemon_battery_stat_dsg_cap) this can be used to calculate total kWh output or even the cost per kWh so far
Example: (devicemon_battery_stat_dsg_cap{unit="bat1"}/1000000)*48

Main Page:
<img width="490" height="463" alt="image" src="https://github.com/user-attachments/assets/d0dde034-e613-4c31-87ab-e6e99822c5bd" />


Settings Page:
<img width="714" height="745" alt="image" src="https://github.com/user-attachments/assets/dd185c0d-af4a-4c0b-bb3e-a627d07d2c7d" />
<img width="697" height="711" alt="image" src="https://github.com/user-attachments/assets/be9e7e74-446c-489b-a43e-d5aa52b828de" />

Example Grafana:
<img width="2189" height="956" alt="image" src="https://github.com/user-attachments/assets/776775d1-e372-4db7-9011-fd6c17d77680" />
Report all Battery lifetime metrics
<img width="2158" height="1033" alt="image" src="https://github.com/user-attachments/assets/e8f9d8a6-7b97-40bc-bc8d-d66f4f57ad54" />

